### PR TITLE
feat: gateway-post-routing

### DIFF
--- a/api-gateway/bin/main/application.yml
+++ b/api-gateway/bin/main/application.yml
@@ -1,3 +1,27 @@
+server:
+  port: 8000
+
 spring:
   application:
     name: api-gateway
+
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: lb://auth-service
+          predicates:
+            - Path=/auth/**
+        - id: post-service
+          uri: lb://post-service
+          predicates:
+            - Path=/posts/**
+        - id: comment-service
+          uri: lb://comment-service
+          predicates:
+            - Path=/comments/**
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -13,7 +13,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
 }
 
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {

--- a/api-gateway/build/resources/main/application.yml
+++ b/api-gateway/build/resources/main/application.yml
@@ -1,3 +1,27 @@
+server:
+  port: 8000
+
 spring:
   application:
     name: api-gateway
+
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: lb://auth-service
+          predicates:
+            - Path=/auth/**
+        - id: post-service
+          uri: lb://post-service
+          predicates:
+            - Path=/posts/**
+        - id: comment-service
+          uri: lb://comment-service
+          predicates:
+            - Path=/comments/**
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,3 +1,27 @@
+server:
+  port: 8000
+
 spring:
   application:
     name: api-gateway
+
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: lb://auth-service
+          predicates:
+            - Path=/auth/**
+        - id: post-service
+          uri: lb://post-service
+          predicates:
+            - Path=/posts/**
+        - id: comment-service
+          uri: lb://comment-service
+          predicates:
+            - Path=/comments/**
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka

--- a/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
+++ b/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
@@ -1,0 +1,12 @@
+package com.devloger.postservice.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PostController {
+    @GetMapping("/posts/test")
+    public String test() {
+        return "Hello World";
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요

- API Gateway를 Eureka에 등록
- post-service와 연동되는 라우팅 흐름 구현 및 테스트 완료

## 🔨 작업 내용 상세

- [x] `api-gateway` 서비스 생성 및 Eureka Client 등록
- [x] `spring-cloud-starter-gateway` 의존성 적용
- [x] application.yml에 `/posts/** → post-service` 라우팅 설정
- [x] post-service의 테스트용 `/posts/test` 엔드포인트 구현
- [x] Gateway를 통한 호출 결과 정상 확인 (curl 또는 브라우저)

## 🧪 테스트 방법

1. `discovery-server` 실행
2. `post-service` 실행 (8082 포트)
3. `api-gateway` 실행 (8000 포트)
4. 브라우저 또는 curl:

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/gateway-post-routing`

## 📎 참고 사항

- `spring-boot-starter-web` → **Gateway에서는 사용 금지**
- `spring-cloud-starter-gateway`는 WebFlux 기반
- Eureka에 서비스 이름으로 등록되므로 `lb://post-service` 구조로 라우팅 가능
- 현재는 인스턴스 1개지만, 로드밸서 구조로 유연성 확보

## 🧩 관련 이슈
