### PR TITLE
feat: JWT 토큰 발급 기능 추가

### DIFF
--- a/auth-service/bin/main/application.yml
+++ b/auth-service/bin/main/application.yml
@@ -11,3 +11,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+jwt:
+  secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!" # 256비트 이상
+  expiration: 3600000 # 1시간 (ms 기준)

--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -16,7 +16,19 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // yml 자동 바인딩
+    implementation("org.springframework.boot:spring-boot-configuration-processor")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
 }
+
 
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {
     mainClass.set("com.devloger.authservice.AuthserviceApplication")

--- a/auth-service/build/resources/main/application.yml
+++ b/auth-service/build/resources/main/application.yml
@@ -11,3 +11,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+jwt:
+  secret: "devloger-secret-key-1234567890" # 길어야 안전함
+  expiration: 3600000 # 1시간 (ms 기준)

--- a/auth-service/src/main/java/com/devloger/authservice/controller/AuthController.java
+++ b/auth-service/src/main/java/com/devloger/authservice/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.devloger.authservice.controller;
+
+import com.devloger.authservice.util.JwtProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        if ("test@example.com".equals(request.getEmail()) && "1234".equals(request.getPassword())) {
+            String token = jwtProvider.createToken("user-1");
+            return ResponseEntity.ok(new LoginResponse(token));
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid credentials");
+    }
+
+    @Getter
+    static class LoginRequest {
+        private String email;
+        private String password;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class LoginResponse {
+        private String token;
+    }
+}

--- a/auth-service/src/main/java/com/devloger/authservice/util/JwtProvider.java
+++ b/auth-service/src/main/java/com/devloger/authservice/util/JwtProvider.java
@@ -1,0 +1,56 @@
+package com.devloger.authservice.util;
+
+import java.util.Date;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+
+@Component
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProvider {
+
+    private String secret;
+    private long expiration;
+
+    public String createToken(String userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secret.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean isValid(String token) {
+        try {
+            getUserId(token); // 파싱 가능하면 유효
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // Setter for application.yml 값 매핑
+    public void setSecret(String secret) { this.secret = secret; }
+    public void setExpiration(long expiration) { this.expiration = expiration; }
+
+}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -11,3 +11,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+jwt:
+  secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!" # 256비트 이상
+  expiration: 3600000 # 1시간 (ms 기준)


### PR DESCRIPTION
## 📌 PR 개요

- `auth-service`에 JWT 토큰 발급 기능 추가

## 🔨 작업 내용 상세

- [x] `POST /auth/login` 엔드포인트 구현
- [x] jjwt 라이브러리 도입 (`0.11.5`)
- [x] JWT 시크릿 키, 만료시간 설정 (`application.yml`)
- [x] `JwtProvider` 유틸 구현
- [x]  하드코딩된 사용자 인증 → 토큰 발급 처리

## 🧪 테스트 방법

```bash
curl -X POST http://localhost:8081/auth/login -H "Content-Type: application/json" -d "{\"email\":\"test@example.com\", \"password\":\"1234\"}"
```
-> JWT 토큰 응답 확인

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/auth-jwt-issuance`

## 📎 참고 사항

- Gateway에 JWT 필터 적용은 다음 단계에서 진행 예정
- 시크릿 키는 최소 256bit 이상 (HS256 요구사항)

## 🧩 관련 이슈

