### PR TITLE
Feat: Gateway에 JWT 인증 필터 및 에러 응답 구조 적용

### DIFF
--- a/api-gateway/bin/main/application.yml
+++ b/api-gateway/bin/main/application.yml
@@ -25,3 +25,6 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+jwt:
+  secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!"

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -16,6 +16,16 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // yml 자동 바인딩
+    implementation("org.springframework.boot:spring-boot-configuration-processor")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
 }
 
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {

--- a/api-gateway/build/resources/main/application.yml
+++ b/api-gateway/build/resources/main/application.yml
@@ -25,3 +25,6 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+jwt:
+  secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!"

--- a/api-gateway/src/main/java/com/devloger/apigateway/config/JwtConfig.java
+++ b/api-gateway/src/main/java/com/devloger/apigateway/config/JwtConfig.java
@@ -1,0 +1,16 @@
+package com.devloger.apigateway.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfig {
+    private String secret;
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+}

--- a/api-gateway/src/main/java/com/devloger/apigateway/dto/ErrorResponse.java
+++ b/api-gateway/src/main/java/com/devloger/apigateway/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.devloger.apigateway.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final String errorCode;
+    private final String message;
+}

--- a/api-gateway/src/main/java/com/devloger/apigateway/exception/JwtErrorType.java
+++ b/api-gateway/src/main/java/com/devloger/apigateway/exception/JwtErrorType.java
@@ -1,0 +1,24 @@
+package com.devloger.apigateway.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum JwtErrorType {
+
+    EXPIRED("JWT_EXPIRED", "Token has expired", HttpStatus.UNAUTHORIZED),
+    UNSUPPORTED("JWT_UNSUPPORTED", "Unsupported JWT", HttpStatus.BAD_REQUEST),
+    MALFORMED("JWT_MALFORMED", "Invalid JWT format", HttpStatus.BAD_REQUEST),
+    SIGNATURE("JWT_INVALID_SIGNATURE", "JWT signature does not match", HttpStatus.UNAUTHORIZED),
+    GENERAL("JWT_INVALID", "JWT validation failed", HttpStatus.UNAUTHORIZED);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    JwtErrorType(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/api-gateway/src/main/java/com/devloger/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/devloger/apigateway/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.devloger.apigateway.filter;
+
+import com.devloger.apigateway.config.JwtConfig;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
+
+    private final JwtConfig jwtConfig; // ✅ 설정 주입받음
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getPath().value();
+        if (path.startsWith("/auth")) {
+            return chain.filter(exchange);
+        }
+
+        String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("Missing or invalid Authorization header");
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        String token = authHeader.replace("Bearer ", "");
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(jwtConfig.getSecret().getBytes(StandardCharsets.UTF_8)) // ✅ yml에서 불러온 secret 사용
+                .build()
+                .parseClaimsJws(token);
+            log.info("JWT 유효성 통과");
+        } catch (JwtException e) {
+            log.warn("JWT 검증 실패: {}", e.getMessage());
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        return chain.filter(exchange);
+    }
+
+    @Override
+    public int getOrder() {
+        return -1;
+    }
+}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -25,3 +25,6 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+jwt:
+  secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!"

--- a/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
+++ b/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
@@ -1,12 +1,16 @@
 package com.devloger.postservice.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class PostController {
+
     @GetMapping("/posts/test")
-    public String test() {
-        return "Hello World";
+    public ResponseEntity<String> test(@RequestHeader("X-User-Id") String userId) {
+    return ResponseEntity.ok("Hello, " + userId + "님! Post 서비스입니다.");
     }
+
 }


### PR DESCRIPTION
## 📌 PR 개요

- API Gateway에 JWT 인증 필터 구현
- 토큰 유효성 검사 및 사용자 ID 헤더 전달 기능 추가
- 예외 상황에 대한 공통 에러 응답 구조 적용

## 🔨 작업 내용 상세

- [x] `JwtAuthenticationFilter` 구현  
  - `/auth` 제외 모든 요청에 대해 JWT 유효성 검증  
  - 토큰에서 사용자 ID 추출 후 `X-User-Id` 헤더로 내부 서비스 전달
- [x] JWT 예외 상황별 에러 메시지 및 상태코드 처리  
  - `ExpiredJwtException`, `MalformedJwtException`, `UnsupportedJwtException` 등 상황별 분기 처리
- [x] 공통 응답 포맷 클래스 `ErrorResponse` 추가
- [x] `JwtErrorType` Enum 생성 (에러 코드, 메시지, HttpStatus 포함)
- [x] 설정값 외부화 (`jwt.secret` → application.yml)
- [x] 테스트용 `/posts/test` 엔드포인트와 연동 테스트 완료

## 🧪 테스트 방법

1. `discovery-server`, `auth-service`, `post-service`, `api-gateway` 순으로 실행
2. `curl` 명령어로 토큰 발급  
   ```bash
   curl -X POST http://localhost:8000/auth/login -H "Content-Type: application/json" -d "{\"email\":\"test@example.com\",\"password\":\"1234\"}"
   ```
3. 발급받은 토큰으로 `/posts/test` 호출  
   ```bash
   curl http://localhost:8000/posts/test -H "Authorization: Bearer <토큰값>"
   ```
4. 유효하지 않은 토큰 요청 시 401/400 응답 및 JSON 에러 확인

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/gateway-jwt-filter`

## 📎 참고 사항

- JWT 검증 시 `jjwt` 라이브러리 사용
- `X-User-Id` 헤더는 내부 서비스에서 사용자 식별 목적으로 활용 가능
- 향후 Role 정보 추가 시 구조 확장 용이함

## 🧩 관련 이슈
