### PR TITLE
feat: db 연동 및 회원가입 API 구현 및 예외 처리 구조 적용

### DIFF
--- a/auth-service/bin/main/application.yml
+++ b/auth-service/bin/main/application.yml
@@ -5,6 +5,20 @@ spring:
   application:
     name: auth-service
 
+  datasource:
+    url: jdbc:mysql://localhost:3306/devloger_auth?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
 eureka:
   client:
     register-with-eureka: true

--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -22,11 +22,23 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+    // OpenAPI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+
     // yml 자동 바인딩
     implementation("org.springframework.boot:spring-boot-configuration-processor")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
+
+    //DB 설정
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-security") // BCrypt
+    runtimeOnly("com.mysql:mysql-connector-j")
+
+    //테스트
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
 

--- a/auth-service/build/resources/main/application.yml
+++ b/auth-service/build/resources/main/application.yml
@@ -5,6 +5,20 @@ spring:
   application:
     name: auth-service
 
+  datasource:
+    url: jdbc:mysql://localhost:3306/devloger_auth?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
 eureka:
   client:
     register-with-eureka: true
@@ -13,5 +27,5 @@ eureka:
       defaultZone: http://localhost:8761/eureka
 
 jwt:
-  secret: "devloger-secret-key-1234567890" # 길어야 안전함
+  secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!" # 256비트 이상
   expiration: 3600000 # 1시간 (ms 기준)

--- a/auth-service/src/main/java/com/devloger/authservice/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/devloger/authservice/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.devloger.authservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers(
+                        "/auth/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html"
+                    ).permitAll()
+                    .anyRequest().permitAll()
+                )
+                .build();
+    }
+} 

--- a/auth-service/src/main/java/com/devloger/authservice/controller/AuthController.java
+++ b/auth-service/src/main/java/com/devloger/authservice/controller/AuthController.java
@@ -1,38 +1,31 @@
 package com.devloger.authservice.controller;
 
-import com.devloger.authservice.util.JwtProvider;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import com.devloger.authservice.domain.User;
+import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.dto.UserSignupResponse;
+import com.devloger.authservice.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
-    private final JwtProvider jwtProvider;
+    private final UserService userService;
 
-    @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        if ("test@example.com".equals(request.getEmail()) && "1234".equals(request.getPassword())) {
-            String token = jwtProvider.createToken("user-1");
-            return ResponseEntity.ok(new LoginResponse(token));
-        }
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid credentials");
-    }
-
-    @Getter
-    static class LoginRequest {
-        private String email;
-        private String password;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    static class LoginResponse {
-        private String token;
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입 진행")
+    public ResponseEntity<UserSignupResponse> signup(@Valid @RequestBody UserSignupRequest request) {
+        User user = userService.signup(request);
+        UserSignupResponse response = UserSignupResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+        return ResponseEntity.ok(response);
     }
 }

--- a/auth-service/src/main/java/com/devloger/authservice/domain/User.java
+++ b/auth-service/src/main/java/com/devloger/authservice/domain/User.java
@@ -1,0 +1,35 @@
+package com.devloger.authservice.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/auth-service/src/main/java/com/devloger/authservice/dto/ErrorResponse.java
+++ b/auth-service/src/main/java/com/devloger/authservice/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.devloger.authservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+} 

--- a/auth-service/src/main/java/com/devloger/authservice/dto/UserSignupRequest.java
+++ b/auth-service/src/main/java/com/devloger/authservice/dto/UserSignupRequest.java
@@ -1,0 +1,15 @@
+package com.devloger.authservice.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserSignupRequest(
+    @Email
+    @NotBlank
+    String email,
+
+    @NotBlank
+    String password,
+
+    String nickname
+) {}

--- a/auth-service/src/main/java/com/devloger/authservice/dto/UserSignupResponse.java
+++ b/auth-service/src/main/java/com/devloger/authservice/dto/UserSignupResponse.java
@@ -1,0 +1,10 @@
+package com.devloger.authservice.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserSignupResponse(
+        Long id,
+        String email,
+        String nickname
+) {}

--- a/auth-service/src/main/java/com/devloger/authservice/exception/CustomException.java
+++ b/auth-service/src/main/java/com/devloger/authservice/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.devloger.authservice.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/auth-service/src/main/java/com/devloger/authservice/exception/ErrorCode.java
+++ b/auth-service/src/main/java/com/devloger/authservice/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.devloger.authservice.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_EMAIL("INVALID_EMAIL", "유효하지 않은 이메일 형식입니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATED_EMAIL("DUPLICATED_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
+    INVALID_PASSWORD("INVALID_PASSWORD", "비밀번호는 최소 8자 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATED_NICKNAME("DUPLICATED_NICKNAME", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+    INVALID_NICKNAME("INVALID_NICKNAME", "닉네임은 2자 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    ErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/auth-service/src/main/java/com/devloger/authservice/exception/ErrorResponse.java
+++ b/auth-service/src/main/java/com/devloger/authservice/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.devloger.authservice.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+}

--- a/auth-service/src/main/java/com/devloger/authservice/exception/GlobalExceptionHandler.java
+++ b/auth-service/src/main/java/com/devloger/authservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.devloger.authservice.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode error = e.getErrorCode();
+        return ResponseEntity
+                .status(error.getStatus())
+                .body(new ErrorResponse(error.getCode(), error.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse("VALIDATION_ERROR", message));
+    }
+}

--- a/auth-service/src/main/java/com/devloger/authservice/repository/UserRepository.java
+++ b/auth-service/src/main/java/com/devloger/authservice/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.devloger.authservice.repository;
+
+import com.devloger.authservice.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
+}

--- a/auth-service/src/main/java/com/devloger/authservice/service/UserService.java
+++ b/auth-service/src/main/java/com/devloger/authservice/service/UserService.java
@@ -2,6 +2,8 @@ package com.devloger.authservice.service;
 
 import com.devloger.authservice.domain.User;
 import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.exception.CustomException;
+import com.devloger.authservice.exception.ErrorCode;
 import com.devloger.authservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -15,6 +17,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@(.+)$");
     private static final int MIN_PASSWORD_LENGTH = 8;
     private static final int MIN_NICKNAME_LENGTH = 2;
@@ -25,11 +28,11 @@ public class UserService {
         validateNickname(request.nickname());
 
         if (userRepository.findByEmail(request.email()).isPresent()) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
         }
 
         if (userRepository.findByNickname(request.nickname()).isPresent()) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
         }
 
         User user = User.builder()
@@ -43,19 +46,19 @@ public class UserService {
 
     private void validateEmail(String email) {
         if (email == null || !EMAIL_PATTERN.matcher(email).matches()) {
-            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
+            throw new CustomException(ErrorCode.INVALID_EMAIL);
         }
     }
 
     private void validatePassword(String password) {
         if (password == null || password.length() < MIN_PASSWORD_LENGTH) {
-            throw new IllegalArgumentException("비밀번호는 최소 8자 이상이어야 합니다.");
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
     }
 
     private void validateNickname(String nickname) {
         if (nickname == null || nickname.length() < MIN_NICKNAME_LENGTH) {
-            throw new IllegalArgumentException("닉네임은 2자 이상이어야 합니다.");
+            throw new CustomException(ErrorCode.INVALID_NICKNAME);
         }
     }
 }

--- a/auth-service/src/main/java/com/devloger/authservice/service/UserService.java
+++ b/auth-service/src/main/java/com/devloger/authservice/service/UserService.java
@@ -1,0 +1,61 @@
+package com.devloger.authservice.service;
+
+import com.devloger.authservice.domain.User;
+import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@(.+)$");
+    private static final int MIN_PASSWORD_LENGTH = 8;
+    private static final int MIN_NICKNAME_LENGTH = 2;
+
+    public User signup(UserSignupRequest request) {
+        validateEmail(request.email());
+        validatePassword(request.password());
+        validateNickname(request.nickname());
+
+        if (userRepository.findByEmail(request.email()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        if (userRepository.findByNickname(request.nickname()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        User user = User.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .nickname(request.nickname())
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || !EMAIL_PATTERN.matcher(email).matches()) {
+            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (password == null || password.length() < MIN_PASSWORD_LENGTH) {
+            throw new IllegalArgumentException("비밀번호는 최소 8자 이상이어야 합니다.");
+        }
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname == null || nickname.length() < MIN_NICKNAME_LENGTH) {
+            throw new IllegalArgumentException("닉네임은 2자 이상이어야 합니다.");
+        }
+    }
+}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -5,6 +5,20 @@ spring:
   application:
     name: auth-service
 
+  datasource:
+    url: jdbc:mysql://localhost:3306/devloger_auth?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
 eureka:
   client:
     register-with-eureka: true

--- a/auth-service/src/test/java/com/devloger/authservice/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/devloger/authservice/controller/AuthControllerTest.java
@@ -1,0 +1,132 @@
+package com.devloger.authservice.controller;
+
+import com.devloger.authservice.domain.User;
+import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("회원가입 API 테스트")
+    class SignupTest {
+        private static final String TEST_EMAIL = "test@example.com";
+        private static final String TEST_PASSWORD = "password123";
+        private static final String TEST_NICKNAME = "testUser";
+        private static final String SIGNUP_URL = "/auth/signup";
+
+        @Test
+        @DisplayName("회원가입 성공")
+        void 회원가입_성공() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest(
+                    TEST_EMAIL,
+                    TEST_PASSWORD,
+                    TEST_NICKNAME
+            );
+
+            User savedUser = User.builder()
+                    .id(1L)
+                    .email(TEST_EMAIL)
+                    .password("encryptedPassword")
+                    .nickname(TEST_NICKNAME)
+                    .build();
+
+            given(userService.signup(any(UserSignupRequest.class))).willReturn(savedUser);
+
+            // when
+            var result = mockMvc.perform(post(SIGNUP_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.email").value(TEST_EMAIL))
+                    .andExpect(jsonPath("$.nickname").value(TEST_NICKNAME));
+        }
+
+        @Test
+        @DisplayName("회원가입 실패 - 이메일 누락")
+        void 회원가입_실패_이메일누락() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest(
+                    null,
+                    TEST_PASSWORD,
+                    TEST_NICKNAME
+            );
+
+            // when
+            var result = mockMvc.perform(post(SIGNUP_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            result.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("회원가입 실패 - 비밀번호 누락")
+        void 회원가입_실패_비밀번호누락() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest(
+                    TEST_EMAIL,
+                    null,
+                    TEST_NICKNAME
+            );
+
+            // when
+            var result = mockMvc.perform(post(SIGNUP_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            result.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("회원가입 실패 - 이메일 형식 오류")
+        void 회원가입_실패_이메일형식오류() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest(
+                    "invalid-email",
+                    TEST_PASSWORD,
+                    TEST_NICKNAME
+            );
+
+            // when
+            var result = mockMvc.perform(post(SIGNUP_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            result.andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/auth-service/src/test/java/com/devloger/authservice/service/UserServiceTest.java
+++ b/auth-service/src/test/java/com/devloger/authservice/service/UserServiceTest.java
@@ -1,0 +1,152 @@
+package com.devloger.authservice.service;
+
+import com.devloger.authservice.domain.User;
+import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private UserService userService;
+    private PasswordEncoder passwordEncoder;
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "testuser";
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new BCryptPasswordEncoder();
+        userService = new UserService(userRepository, passwordEncoder);
+    }
+
+    private User createTestUser(String email, String password, String nickname) {
+        return User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .nickname(nickname)
+                .build();
+    }
+
+    private UserSignupRequest createSignupRequest(String email, String password, String nickname) {
+        return new UserSignupRequest(email, password, nickname);
+    }
+
+    @Nested
+    class SignupTest {
+        @Test
+        void 회원가입_성공() {
+            // given
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+            User savedUser = createTestUser(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+            when(userRepository.findByNickname(TEST_NICKNAME)).thenReturn(Optional.empty());
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+            // when
+            User result = userService.signup(request);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getEmail()).isEqualTo(TEST_EMAIL);
+            assertThat(passwordEncoder.matches(TEST_PASSWORD, result.getPassword())).isTrue();
+            assertThat(result.getNickname()).isEqualTo(TEST_NICKNAME);
+            
+            verify(userRepository).save(any(User.class));
+        }
+
+        @Test
+        void 회원가입_실패_중복이메일() {
+            // given
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+            User existingUser = createTestUser(TEST_EMAIL, "existingPassword", "existingUser");
+
+            when(userRepository.findByEmail(TEST_EMAIL))
+                    .thenReturn(Optional.of(existingUser));
+
+            // when & then
+            assertThatThrownBy(() -> userService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미 사용 중인 이메일입니다.");
+
+            verify(userRepository, never()).save(any());
+        }
+
+
+        @Test
+        void 회원가입_실패_중복닉네임() {
+            // given
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+            User existingUser = createTestUser("existing@example.com", "existingPassword", TEST_NICKNAME);
+
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+            when(userRepository.findByNickname(TEST_NICKNAME))
+                    .thenReturn(Optional.of(existingUser));
+
+            // when & then
+            assertThatThrownBy(() -> userService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미 사용 중인 닉네임입니다.");
+
+            verify(userRepository, never()).save(any());
+        }
+
+
+        @Test
+        void 회원가입_실패_유효하지않은이메일() {
+            // given
+            String invalidEmail = "invalid-email";
+            UserSignupRequest request = createSignupRequest(invalidEmail, TEST_PASSWORD, TEST_NICKNAME);
+
+            // when & then
+            assertThatThrownBy(() -> userService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("유효하지 않은 이메일 형식입니다.");
+        }
+
+
+        @Test
+        void 회원가입_실패_비밀번호길이부족() {
+            // given
+            String shortPassword = "123"; // 3자리
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, shortPassword, TEST_NICKNAME);
+
+            // when & then
+            assertThatThrownBy(() -> userService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("비밀번호는 최소 8자 이상이어야 합니다.");
+        }
+
+
+        @Test
+        void 회원가입_실패_유효하지않은닉네임() {
+            // given
+            String invalidNickname = "a"; // 너무 짧은 닉네임
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, invalidNickname);
+
+            // when & then
+            assertThatThrownBy(() -> userService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("닉네임은 2자 이상이어야 합니다.");
+        }
+    }
+}

--- a/auth-service/src/test/java/com/devloger/authservice/service/UserServiceTest.java
+++ b/auth-service/src/test/java/com/devloger/authservice/service/UserServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 


### PR DESCRIPTION
## 📌 PR 개요

- `auth-service`에 MySQL DB 연동
- 회원가입(Signup) 기능 구현
- 예외 처리 공통 구조 (`CustomException`, `ErrorCode`, `GlobalExceptionHandler`) 적용
- Controller & Service 단위 테스트 작성
- Swagger 문서화 적용

## 🔨 작업 내용 상세

- [x] MySQL 컨테이너 구성 및 DB 연동 (`docker run`, `application.yml`)
- [x] `User` 엔티티 생성 및 JPA 설정
- [x] `POST /auth/signup` API 구현
- [x] 이메일/비밀번호/닉네임 유효성 검사 (`@Valid + 서비스 내 로직`)
- [x] DB 중복 검사 및 암호화 저장 (`BCryptPasswordEncoder`)
- [x] 공통 예외 구조 도입
  - `ErrorCode` enum
  - `CustomException`
  - `GlobalExceptionHandler`
  - `ErrorResponse` JSON 응답 포맷
- [x] Swagger 문서 자동화 (`springdoc-openapi` 적용)
- [x] 테스트 코드 작성:
  - `UserServiceTest`: 정상 흐름 + 예외 흐름 전부 커버
  - `AuthControllerTest`: 응답 JSON 구조, 상태코드 검증

## 🧪 테스트 방법

1. Docker로 MySQL 컨테이너 실행
   ```bash
   docker run --name mysql-devloger-auth -e MYSQL_ROOT_PASSWORD=1234 -e MYSQL_DATABASE=devloger_auth -p 3306:3306 -d mysql:8
   ```
2. `auth-service` 실행
3. Swagger 접속: [http://localhost:8081/swagger-ui/index.html](http://localhost:8081/swagger-ui/index.html)
4. `/auth/signup` API 호출
5. 성공 시 200 OK + 응답 JSON
6. 실패 시 400/409 + `"code"` + `"message"` 포함된 에러 응답
## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/auth-user-db-integration`

## 📎 참고 사항

- Spring Boot 3.2.3 / Spring Cloud 2023.0.1 / Java 17 환경
- `docker run`으로 로컬 MySQL 환경 구성
- DB 연동은 포트 3306 기준 `localhost` 접속 (`application.yml` 구성 포함)
- 테스트 환경에서 `@AutoConfigureMockMvc(addFilters = false)`로 Security 필터 우회
- Swagger 문서 자동화 및 테스트 가능 상태 유지

## 🧩 관련 이슈

