### PR TITLE
feat: 로그인 API 구현 및 JWT 토큰 발급 기능 추가

### DIFF
--- a/auth-service/src/main/java/com/devloger/authservice/controller/AuthController.java
+++ b/auth-service/src/main/java/com/devloger/authservice/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.devloger.authservice.controller;
 import com.devloger.authservice.domain.User;
 import com.devloger.authservice.dto.UserSignupRequest;
 import com.devloger.authservice.dto.UserSignupResponse;
+import com.devloger.authservice.dto.UserLoginRequest;
+import com.devloger.authservice.dto.UserLoginResponse;
 import com.devloger.authservice.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -27,5 +29,11 @@ public class AuthController {
                 .nickname(user.getNickname())
                 .build();
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인 후 JWT 토큰 발급")
+    public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody UserLoginRequest request) {
+        return ResponseEntity.ok(userService.login(request));
     }
 }

--- a/auth-service/src/main/java/com/devloger/authservice/dto/UserLoginRequest.java
+++ b/auth-service/src/main/java/com/devloger/authservice/dto/UserLoginRequest.java
@@ -1,15 +1,10 @@
 package com.devloger.authservice.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record UserSignupRequest(
-    @Email
+public record UserLoginRequest(
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     String email,
-
     @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-    String password,
-
-    String nickname
+    String password
 ) {}

--- a/auth-service/src/main/java/com/devloger/authservice/dto/UserLoginResponse.java
+++ b/auth-service/src/main/java/com/devloger/authservice/dto/UserLoginResponse.java
@@ -1,0 +1,8 @@
+package com.devloger.authservice.dto;
+
+public record UserLoginResponse(
+    Long id,
+    String email,
+    String nickname,
+    String accessToken
+) {}

--- a/auth-service/src/main/java/com/devloger/authservice/exception/ErrorCode.java
+++ b/auth-service/src/main/java/com/devloger/authservice/exception/ErrorCode.java
@@ -10,7 +10,9 @@ public enum ErrorCode {
     DUPLICATED_EMAIL("DUPLICATED_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
     INVALID_PASSWORD("INVALID_PASSWORD", "비밀번호는 최소 8자 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
     DUPLICATED_NICKNAME("DUPLICATED_NICKNAME", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
-    INVALID_NICKNAME("INVALID_NICKNAME", "닉네임은 2자 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+    INVALID_NICKNAME("INVALID_NICKNAME", "닉네임은 2자 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("USER_NOT_FOUND", "해당 사용자가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    INVALID_CREDENTIALS("INVALID_CREDENTIALS", "이메일 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/auth-service/src/main/java/com/devloger/authservice/service/UserService.java
+++ b/auth-service/src/main/java/com/devloger/authservice/service/UserService.java
@@ -2,9 +2,12 @@ package com.devloger.authservice.service;
 
 import com.devloger.authservice.domain.User;
 import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.dto.UserLoginRequest;
+import com.devloger.authservice.dto.UserLoginResponse;
 import com.devloger.authservice.exception.CustomException;
 import com.devloger.authservice.exception.ErrorCode;
 import com.devloger.authservice.repository.UserRepository;
+import com.devloger.authservice.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,18 +18,33 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-
+    // 상수 정의
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@(.+)$");
     private static final int MIN_PASSWORD_LENGTH = 8;
     private static final int MIN_NICKNAME_LENGTH = 2;
 
+    // 의존성 주입
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    /**
+     * 회원가입을 처리합니다.
+     * 1. 입력값 유효성 검증
+     * 2. 중복 체크
+     * 3. 비밀번호 암호화
+     * 4. 사용자 저장
+     *
+     * @param request 회원가입 요청 정보
+     * @return 저장된 사용자 정보
+     */
     public User signup(UserSignupRequest request) {
+        // 1. 입력값 유효성 검증
         validateEmail(request.email());
         validatePassword(request.password());
         validateNickname(request.nickname());
 
+        // 2. 중복 체크
         if (userRepository.findByEmail(request.email()).isPresent()) {
             throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
         }
@@ -35,27 +53,79 @@ public class UserService {
             throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
         }
 
+        // 3. 비밀번호 암호화 및 사용자 생성
         User user = User.builder()
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .nickname(request.nickname())
                 .build();
 
+        // 4. 사용자 저장
         return userRepository.save(user);
     }
 
+    /**
+     * 로그인을 처리합니다.
+     * 1. 사용자 조회
+     * 2. 비밀번호 확인
+     * 3. JWT 토큰 발급
+     * 4. 응답 반환
+     *
+     * @param request 로그인 요청 정보
+     * @return 로그인 응답 (사용자 정보 + JWT 토큰)
+     */
+    public UserLoginResponse login(UserLoginRequest request) {
+        // 1. 사용자 조회
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 비밀번호 확인
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 3. JWT 토큰 발급
+        String token = jwtProvider.createToken(user.getId(), user.getEmail(), user.getNickname());
+
+        // 4. 응답 반환
+        return new UserLoginResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                token
+        );
+    }
+
+    /**
+     * 이메일 유효성을 검증합니다.
+     *
+     * @param email 검증할 이메일
+     * @throws CustomException 이메일이 null이거나 형식이 올바르지 않은 경우
+     */
     private void validateEmail(String email) {
         if (email == null || !EMAIL_PATTERN.matcher(email).matches()) {
             throw new CustomException(ErrorCode.INVALID_EMAIL);
         }
     }
 
+    /**
+     * 비밀번호 유효성을 검증합니다.
+     *
+     * @param password 검증할 비밀번호
+     * @throws CustomException 비밀번호가 null이거나 최소 길이보다 짧은 경우
+     */
     private void validatePassword(String password) {
         if (password == null || password.length() < MIN_PASSWORD_LENGTH) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
     }
 
+    /**
+     * 닉네임 유효성을 검증합니다.
+     *
+     * @param nickname 검증할 닉네임
+     * @throws CustomException 닉네임이 null이거나 최소 길이보다 짧은 경우
+     */
     private void validateNickname(String nickname) {
         if (nickname == null || nickname.length() < MIN_NICKNAME_LENGTH) {
             throw new CustomException(ErrorCode.INVALID_NICKNAME);

--- a/auth-service/src/main/java/com/devloger/authservice/util/JwtProvider.java
+++ b/auth-service/src/main/java/com/devloger/authservice/util/JwtProvider.java
@@ -9,7 +9,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
-
+import io.jsonwebtoken.Claims;
 
 @Component
 @RequiredArgsConstructor
@@ -19,38 +19,21 @@ public class JwtProvider {
     private String secret;
     private long expiration;
 
-    public String createToken(String userId) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + expiration);
+    public String createToken(Long userId, String email, String nickname) {
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId);
+        claims.put("email", email);
+        claims.put("nickname", nickname);
 
         return Jwts.builder()
-                .setSubject(userId)
-                .setIssuedAt(now)
-                .setExpiration(expiry)
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
                 .compact();
-    }
-
-    public String getUserId(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secret.getBytes())
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
-    }
-
-    public boolean isValid(String token) {
-        try {
-            getUserId(token); // 파싱 가능하면 유효
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     // Setter for application.yml 값 매핑
     public void setSecret(String secret) { this.secret = secret; }
     public void setExpiration(long expiration) { this.expiration = expiration; }
-
 }

--- a/auth-service/src/test/java/com/devloger/authservice/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/devloger/authservice/controller/AuthControllerTest.java
@@ -2,6 +2,8 @@ package com.devloger.authservice.controller;
 
 import com.devloger.authservice.domain.User;
 import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.dto.UserLoginRequest;
+import com.devloger.authservice.dto.UserLoginResponse;
 import com.devloger.authservice.exception.CustomException;
 import com.devloger.authservice.exception.ErrorCode;
 import com.devloger.authservice.service.UserService;
@@ -15,10 +17,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -35,61 +37,190 @@ class AuthControllerTest {
     @MockBean
     private UserService userService;
 
+    // API 엔드포인트
+    private static final String SIGNUP_URL = "/auth/signup";
+    private static final String LOGIN_URL = "/auth/login";
+
+    // 테스트 데이터
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "testuser";
+    private static final Long TEST_USER_ID = 1L;
+    private static final String TEST_TOKEN = "jwt-token";
+
+    // 유효성 검증 메시지
+    private static final String VALIDATION_ERROR_CODE = "VALIDATION_ERROR";
+    private static final String EMAIL_NOT_BLANK_MESSAGE = "이메일은 필수 입력값입니다.";
+    private static final String PASSWORD_NOT_BLANK_MESSAGE = "비밀번호는 필수 입력값입니다.";
+    private static final String INVALID_EMAIL_MESSAGE = "must be a well-formed email address";
+
     @Nested
     @DisplayName("회원가입 API 테스트")
     class SignupTest {
-        private static final String EMAIL = "test@example.com";
-        private static final String PASSWORD = "password123";
-        private static final String NICKNAME = "testUser";
 
         @Test
         @DisplayName("회원가입 성공")
-        void signup_success() throws Exception {
-            User user = User.builder()
-                    .id(1L)
-                    .email(EMAIL)
-                    .password("encrypted")
-                    .nickname(NICKNAME)
-                    .build();
+        void 회원가입_성공() throws Exception {
+            // given
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+            User user = createUser(TEST_USER_ID, TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+            when(userService.signup(any(UserSignupRequest.class))).thenReturn(user);
 
-            given(userService.signup(any())).willReturn(user);
-
-            mockMvc.perform(post("/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(new UserSignupRequest(EMAIL, PASSWORD, NICKNAME))))
+            // when & then
+            performSignupRequest(request)
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.id").value(1L))
-                    .andExpect(jsonPath("$.email").value(EMAIL))
-                    .andExpect(jsonPath("$.nickname").value(NICKNAME));
+                    .andExpect(jsonPath("$.id").value(TEST_USER_ID))
+                    .andExpect(jsonPath("$.email").value(TEST_EMAIL))
+                    .andExpect(jsonPath("$.nickname").value(TEST_NICKNAME));
         }
 
         @Test
         @DisplayName("회원가입 실패 - 유효하지 않은 이메일 형식")
-        void signup_fail_invalid_email() throws Exception {
-            UserSignupRequest request = new UserSignupRequest("invalid-email", PASSWORD, NICKNAME);
+        void 회원가입_실패_유효하지_않은_이메일_형식() throws Exception {
+            // given
+            UserSignupRequest request = createSignupRequest("invalid-email", TEST_PASSWORD, TEST_NICKNAME);
 
-            mockMvc.perform(post("/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+            // when & then
+            performSignupRequest(request)
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
-                    .andExpect(jsonPath("$.message").value("must be a well-formed email address"));
+                    .andExpect(jsonPath("$.code").value(VALIDATION_ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(INVALID_EMAIL_MESSAGE));
         }
 
         @Test
-        @DisplayName("회원가입 실패 - 비밀번호 길이 부족")
-        void signup_fail_short_password() throws Exception {
-            UserSignupRequest request = new UserSignupRequest(EMAIL, "123", NICKNAME);
-            doThrow(new CustomException(ErrorCode.INVALID_PASSWORD))
-                    .when(userService)
-                    .signup(any());
+        @DisplayName("회원가입 실패 - 이메일 누락")
+        void 회원가입_실패_이메일_누락() throws Exception {
+            // given
+            UserSignupRequest request = createSignupRequest(null, TEST_PASSWORD, TEST_NICKNAME);
 
-            mockMvc.perform(post("/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+            // when & then
+            performSignupRequest(request)
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_PASSWORD.name()))
-                    .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_PASSWORD.getMessage()));
+                    .andExpect(jsonPath("$.code").value(VALIDATION_ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(EMAIL_NOT_BLANK_MESSAGE));
         }
+
+        @Test
+        @DisplayName("회원가입 실패 - 비밀번호 누락")
+        void 회원가입_실패_비밀번호_누락() throws Exception {
+            // given
+            UserSignupRequest request = createSignupRequest(TEST_EMAIL, null, TEST_NICKNAME);
+
+            // when & then
+            performSignupRequest(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(VALIDATION_ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(PASSWORD_NOT_BLANK_MESSAGE));
+        }
+
+        private ResultActions performSignupRequest(UserSignupRequest request) throws Exception {
+            return mockMvc.perform(post(SIGNUP_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 API 테스트")
+    class LoginTest {
+
+        @Test
+        @DisplayName("로그인 성공")
+        void 로그인_성공() throws Exception {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+            UserLoginResponse response = createLoginResponse(TEST_USER_ID, TEST_EMAIL, TEST_NICKNAME, TEST_TOKEN);
+            when(userService.login(any(UserLoginRequest.class))).thenReturn(response);
+
+            // when & then
+            performLoginRequest(request)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(TEST_USER_ID))
+                    .andExpect(jsonPath("$.email").value(TEST_EMAIL))
+                    .andExpect(jsonPath("$.nickname").value(TEST_NICKNAME))
+                    .andExpect(jsonPath("$.accessToken").exists());
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 이메일 누락")
+        void 로그인_실패_이메일_누락() throws Exception {
+            // given
+            UserLoginRequest request = createLoginRequest(null, TEST_PASSWORD);
+
+            // when & then
+            performLoginRequest(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(VALIDATION_ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(EMAIL_NOT_BLANK_MESSAGE));
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 비밀번호 누락")
+        void 로그인_실패_비밀번호_누락() throws Exception {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, null);
+
+            // when & then
+            performLoginRequest(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(VALIDATION_ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(PASSWORD_NOT_BLANK_MESSAGE));
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 존재하지 않는 사용자")
+        void 로그인_실패_존재하지_않는_사용자() throws Exception {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+            when(userService.login(any(UserLoginRequest.class)))
+                    .thenThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            performLoginRequest(request)
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.name()));
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 잘못된 비밀번호")
+        void 로그인_실패_잘못된_비밀번호() throws Exception {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, "wrong-password");
+            when(userService.login(any(UserLoginRequest.class)))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+            // when & then
+            performLoginRequest(request)
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_CREDENTIALS.name()));
+        }
+
+        private ResultActions performLoginRequest(UserLoginRequest request) throws Exception {
+            return mockMvc.perform(post(LOGIN_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+        }
+    }
+
+    // 테스트 데이터 생성 메서드
+    private UserSignupRequest createSignupRequest(String email, String password, String nickname) {
+        return new UserSignupRequest(email, password, nickname);
+    }
+
+    private UserLoginRequest createLoginRequest(String email, String password) {
+        return new UserLoginRequest(email, password);
+    }
+
+    private User createUser(Long id, String email, String password, String nickname) {
+        return User.builder()
+                .id(id)
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .build();
+    }
+
+    private UserLoginResponse createLoginResponse(Long id, String email, String nickname, String token) {
+        return new UserLoginResponse(id, email, nickname, token);
     }
 }

--- a/auth-service/src/test/java/com/devloger/authservice/service/UserServiceTest.java
+++ b/auth-service/src/test/java/com/devloger/authservice/service/UserServiceTest.java
@@ -2,10 +2,14 @@ package com.devloger.authservice.service;
 
 import com.devloger.authservice.domain.User;
 import com.devloger.authservice.dto.UserSignupRequest;
+import com.devloger.authservice.dto.UserLoginRequest;
+import com.devloger.authservice.dto.UserLoginResponse;
 import com.devloger.authservice.exception.CustomException;
 import com.devloger.authservice.exception.ErrorCode;
 import com.devloger.authservice.repository.UserRepository;
+import com.devloger.authservice.util.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,22 +28,41 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private JwtProvider jwtProvider;
 
     private UserService userService;
     private PasswordEncoder passwordEncoder;
 
+    // 테스트 데이터
     private static final String TEST_EMAIL = "test@example.com";
     private static final String TEST_PASSWORD = "password123";
     private static final String TEST_NICKNAME = "testuser";
+    private static final Long TEST_USER_ID = 1L;
+    private static final String TEST_TOKEN = "test-jwt-token";
 
     @BeforeEach
     void setUp() {
         passwordEncoder = new BCryptPasswordEncoder();
-        userService = new UserService(userRepository, passwordEncoder);
+        userService = new UserService(userRepository, passwordEncoder, jwtProvider);
     }
 
+    // 테스트 데이터 생성 메서드
     private UserSignupRequest createSignupRequest(String email, String password, String nickname) {
         return new UserSignupRequest(email, password, nickname);
+    }
+
+    private UserLoginRequest createLoginRequest(String email, String password) {
+        return new UserLoginRequest(email, password);
+    }
+
+    private User createUser(Long id, String email, String password, String nickname) {
+        return User.builder()
+                .id(id)
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .build();
     }
 
     private void assertCustomException(Throwable e, ErrorCode expectedCode) {
@@ -48,20 +71,23 @@ class UserServiceTest {
     }
 
     @Nested
+    @DisplayName("회원가입 서비스 테스트")
     class SignupTest {
 
         @Test
+        @DisplayName("회원가입 성공")
         void 회원가입_성공() {
+            // given
             UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
 
             when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
             when(userRepository.findByNickname(TEST_NICKNAME)).thenReturn(Optional.empty());
+            when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-            when(userRepository.save(any(User.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
-
+            // when
             User result = userService.signup(request);
 
+            // then
             assertThat(result.getEmail()).isEqualTo(TEST_EMAIL);
             assertThat(passwordEncoder.matches(TEST_PASSWORD, result.getPassword())).isTrue();
             assertThat(result.getNickname()).isEqualTo(TEST_NICKNAME);
@@ -70,43 +96,135 @@ class UserServiceTest {
         }
 
         @Test
-        void 중복이메일_회원가입_실패() {
+        @DisplayName("회원가입 실패 - 중복 이메일")
+        void 회원가입_실패_중복_이메일() {
+            // given
             UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
             when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(mock(User.class)));
 
+            // when
             Throwable e = catchThrowable(() -> userService.signup(request));
+
+            // then
             assertCustomException(e, ErrorCode.DUPLICATED_EMAIL);
         }
 
         @Test
-        void 중복닉네임_회원가입_실패() {
+        @DisplayName("회원가입 실패 - 중복 닉네임")
+        void 회원가입_실패_중복_닉네임() {
+            // given
             UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
             when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
             when(userRepository.findByNickname(TEST_NICKNAME)).thenReturn(Optional.of(mock(User.class)));
 
+            // when
             Throwable e = catchThrowable(() -> userService.signup(request));
+
+            // then
             assertCustomException(e, ErrorCode.DUPLICATED_NICKNAME);
         }
 
         @Test
-        void 이메일형식_잘못됨() {
+        @DisplayName("회원가입 실패 - 유효하지 않은 이메일 형식")
+        void 회원가입_실패_유효하지_않은_이메일_형식() {
+            // given
             UserSignupRequest request = createSignupRequest("invalid-email", TEST_PASSWORD, TEST_NICKNAME);
+
+            // when
             Throwable e = catchThrowable(() -> userService.signup(request));
+
+            // then
             assertCustomException(e, ErrorCode.INVALID_EMAIL);
         }
 
         @Test
-        void 비밀번호길이_부족() {
+        @DisplayName("회원가입 실패 - 비밀번호 길이 부족")
+        void 회원가입_실패_비밀번호_길이_부족() {
+            // given
             UserSignupRequest request = createSignupRequest(TEST_EMAIL, "123", TEST_NICKNAME);
+
+            // when
             Throwable e = catchThrowable(() -> userService.signup(request));
+
+            // then
             assertCustomException(e, ErrorCode.INVALID_PASSWORD);
         }
 
         @Test
-        void 닉네임길이_부족() {
+        @DisplayName("회원가입 실패 - 닉네임 길이 부족")
+        void 회원가입_실패_닉네임_길이_부족() {
+            // given
             UserSignupRequest request = createSignupRequest(TEST_EMAIL, TEST_PASSWORD, "a");
+
+            // when
             Throwable e = catchThrowable(() -> userService.signup(request));
+
+            // then
             assertCustomException(e, ErrorCode.INVALID_NICKNAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 서비스 테스트")
+    class LoginTest {
+
+        @Test
+        @DisplayName("로그인 성공")
+        void 로그인_성공() {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+            String encodedPassword = passwordEncoder.encode(TEST_PASSWORD);
+            User user = createUser(TEST_USER_ID, TEST_EMAIL, encodedPassword, TEST_NICKNAME);
+
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(user));
+            when(jwtProvider.createToken(TEST_USER_ID, TEST_EMAIL, TEST_NICKNAME)).thenReturn(TEST_TOKEN);
+
+            // when
+            UserLoginResponse response = userService.login(request);
+
+            // then
+            assertThat(response.id()).isEqualTo(TEST_USER_ID);
+            assertThat(response.email()).isEqualTo(TEST_EMAIL);
+            assertThat(response.nickname()).isEqualTo(TEST_NICKNAME);
+            assertThat(response.accessToken()).isEqualTo(TEST_TOKEN);
+
+            verify(userRepository).findByEmail(TEST_EMAIL);
+            verify(jwtProvider).createToken(TEST_USER_ID, TEST_EMAIL, TEST_NICKNAME);
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 존재하지 않는 사용자")
+        void 로그인_실패_존재하지_않는_사용자() {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+
+            // when
+            Throwable e = catchThrowable(() -> userService.login(request));
+
+            // then
+            assertCustomException(e, ErrorCode.USER_NOT_FOUND);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+            verifyNoInteractions(jwtProvider);
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 잘못된 비밀번호")
+        void 로그인_실패_잘못된_비밀번호() {
+            // given
+            UserLoginRequest request = createLoginRequest(TEST_EMAIL, "wrong-password");
+            String encodedPassword = passwordEncoder.encode(TEST_PASSWORD);
+            User user = createUser(TEST_USER_ID, TEST_EMAIL, encodedPassword, TEST_NICKNAME);
+
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(user));
+
+            // when
+            Throwable e = catchThrowable(() -> userService.login(request));
+
+            // then
+            assertCustomException(e, ErrorCode.INVALID_CREDENTIALS);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+            verifyNoInteractions(jwtProvider);
         }
     }
 }


### PR DESCRIPTION
## 📌 PR 개요

- 사용자 로그인 기능 (`POST /auth/login`) 구현
- JWT 기반 인증 토큰 발급
- 로그인 실패 시 일관된 예외 처리 적용 (`INVALID_CREDENTIALS`)
- 관련 단위 테스트 및 문서화(Swagger) 완료

## 🔨 작업 내용 상세

- [x] 로그인 요청 DTO (`UserLoginRequest`) 및 응답 DTO (`UserLoginResponse`) 정의
- [x] `UserService#login()` 구현
  - 이메일로 사용자 조회
  - 비밀번호 검증 (`BCryptPasswordEncoder`)
  - JWT 생성 (기존 `JwtProvider` 활용, claim 포함)
- [x] `JwtProvider#createToken(userId, email, nickname)` 확장
- [x] 에러 코드 추가 및 통일:
  - `INVALID_CREDENTIALS`: 이메일 또는 비밀번호 오류 시 통합
- [x] `POST /auth/login` 컨트롤러 구현
- [x] Swagger 문서 설명 추가
- [x] 테스트 코드
  - `UserServiceTest`: 로그인 성공 + 실패 (비번, 이메일 오류)
  - `AuthControllerTest`: 로그인 성공/실패 응답 구조 검증

## 🧪 테스트 방법

1. Swagger 접속 → [http://localhost:8081/swagger-ui/index.html](http://localhost:8081/swagger-ui/index.html)
2. `POST /auth/login` 요청
   - 성공: 200 OK + 응답 JSON (accessToken 포함)
   - 실패: 401 Unauthorized + `"code": "INVALID_CREDENTIALS"` 응답
3. DB에 있는 회원 정보로 테스트 필요 (사전 회원가입 or SQL insert)

## 🔄 변경 브랜치


- **Base branch:** `develop`
- **Target branch:** `feature/auth-login-jwt-issue`

## 📎 참고 사항

- 기존 `JwtProvider`에 `setClaims()` 방식으로 claim 추가 적용
- 로그인 시 email/nickname도 토큰에 포함되어 발급
- 토큰의 `subject`는 `userId`
- 테스트 코드에서 예외 메시지 대신 `ErrorCode` 기준으로 검증
- 추후 작업 예정:
  - `/auth/me` 사용자 정보 조회
  - Gateway의 JWT 인증 필터 적용
  - Refresh Token 도입 (Redis 기반) → MSA 완성 후 고도화

## 🧩 관련 이슈

