### PR TITLE
feat: 게시글 목록 조회 API 구현 (페이징 및 정렬 포함)

### DIFF
--- a/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
+++ b/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
@@ -2,10 +2,16 @@ package com.devloger.postservice.controller;
 
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
+import com.devloger.postservice.dto.PostListResponse;
+import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,4 +35,14 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 조회", description = "전체 게시글을 페이징하여 조회합니다.")
+    public ResponseEntity<PostListResponse> getPosts(
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable
+    ) {
+        Page<PostSummaryResponse> page = postService.getPosts(pageable);
+        return ResponseEntity.ok(PostListResponse.from(page));
+    }
 }

--- a/post-service/src/main/java/com/devloger/postservice/dto/PostListResponse.java
+++ b/post-service/src/main/java/com/devloger/postservice/dto/PostListResponse.java
@@ -1,0 +1,25 @@
+package com.devloger.postservice.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record PostListResponse(
+    List<PostSummaryResponse> posts,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean isLast
+) {
+    public static PostListResponse from(Page<PostSummaryResponse> page) {
+        return new PostListResponse(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.isLast()
+        );
+    }
+}

--- a/post-service/src/main/java/com/devloger/postservice/dto/PostSummaryResponse.java
+++ b/post-service/src/main/java/com/devloger/postservice/dto/PostSummaryResponse.java
@@ -2,8 +2,22 @@ package com.devloger.postservice.dto;
 
 import java.time.LocalDateTime;
 
+import com.devloger.postservice.domain.Post;
+
 public record PostSummaryResponse(
     Long id,
     String title,
+    String content,
+    Long userId,
     LocalDateTime createdAt
-) {}
+) {
+    public static PostSummaryResponse from(Post post) {
+        return new PostSummaryResponse(
+            post.getId(),
+            post.getTitle(),
+            post.getContent(),
+            post.getUserId(),
+            post.getCreatedAt()
+        );
+    }
+}

--- a/post-service/src/main/java/com/devloger/postservice/service/PostService.java
+++ b/post-service/src/main/java/com/devloger/postservice/service/PostService.java
@@ -3,8 +3,11 @@ package com.devloger.postservice.service;
 import com.devloger.postservice.domain.Post;
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
+import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -32,6 +35,11 @@ public class PostService {
                 saved.getUserId(),
                 saved.getCreatedAt()
         );
+    }
+
+    public Page<PostSummaryResponse> getPosts(Pageable pageable) {
+        return postRepository.findAll(pageable)
+                .map(PostSummaryResponse::from);
     }
 
     private void validateRequest(PostCreateRequest request) {

--- a/post-service/src/test/java/com/devloger/postservice/controller/PostControllerTest.java
+++ b/post-service/src/test/java/com/devloger/postservice/controller/PostControllerTest.java
@@ -2,6 +2,8 @@ package com.devloger.postservice.controller;
 
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
+import com.devloger.postservice.dto.PostListResponse;
+import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.service.PostService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -11,14 +13,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,13 +44,13 @@ class PostControllerTest {
     @MockBean
     private PostService postService;
 
-    // API 엔드포인트
     private static final String CREATE_URL = "/posts";
+    private static final String GET_POSTS_URL = "/posts";
 
-    // 테스트 데이터
     private static final Long TEST_USER_ID = 1L;
     private static final String TEST_TITLE = "테스트 제목";
     private static final String TEST_CONTENT = "테스트 본문입니다.";
+    private static final LocalDateTime TEST_CREATED_AT = LocalDateTime.now();
 
     @Nested
     @DisplayName("게시글 작성 API 테스트")
@@ -115,10 +123,73 @@ class PostControllerTest {
 
     }
 
+    @Nested
+    @DisplayName("게시글 목록 조회 API 테스트")
+    class GetPostsTest {
 
+        @Test
+        @DisplayName("게시글 목록 조회 성공")
+        void 게시글_목록_조회_성공() throws Exception {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            List<PostSummaryResponse> posts = List.of(
+                new PostSummaryResponse(1L, "제목1", "내용1", 1L, TEST_CREATED_AT),
+                new PostSummaryResponse(2L, "제목2", "내용2", 2L, TEST_CREATED_AT)
+            );
+            Page<PostSummaryResponse> postPage = new PageImpl<>(posts, pageable, 2);
+            
+            when(postService.getPosts(any(Pageable.class))).thenReturn(postPage);
 
-    
+            // when & then
+            mockMvc.perform(get(GET_POSTS_URL)
+                    .param("page", "0")
+                    .param("size", "10")
+                    .param("sort", "createdAt,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts").isArray())
+                .andExpect(jsonPath("$.posts.length()").value(2))
+                .andExpect(jsonPath("$.posts[0].id").value(1L))
+                .andExpect(jsonPath("$.posts[0].title").value("제목1"))
+                .andExpect(jsonPath("$.posts[0].content").value("내용1"))
+                .andExpect(jsonPath("$.posts[0].userId").value(1L))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(10))
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.isLast").value(true));
+        }
 
+        @Test
+        @DisplayName("게시글 목록 조회 성공 - 빈 결과")
+        void 게시글_목록_조회_성공_빈결과() throws Exception {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<PostSummaryResponse> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+            
+            when(postService.getPosts(any(Pageable.class))).thenReturn(emptyPage);
+
+            // when & then
+            mockMvc.perform(get(GET_POSTS_URL)
+                    .param("page", "0")
+                    .param("size", "10")
+                    .param("sort", "createdAt,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts").isArray())
+                .andExpect(jsonPath("$.posts.length()").value(0))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(10))
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.totalPages").value(0))
+                .andExpect(jsonPath("$.isLast").value(true));
+        }
+    }
+
+    private ResultActions performCreateRequest(PostCreateRequest request) throws Exception {
+        return mockMvc.perform(post(CREATE_URL)
+                .header("X-User-Id", TEST_USER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+    }
 
     // 테스트 요청 생성 메서드
     private PostCreateRequest createPostRequest(String title, String content) {

--- a/post-service/src/test/java/com/devloger/postservice/service/PostServiceTest.java
+++ b/post-service/src/test/java/com/devloger/postservice/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.devloger.postservice.service;
 import com.devloger.postservice.domain.Post;
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
+import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,8 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -112,6 +118,64 @@ class PostServiceTest {
             assertThatThrownBy(() -> postService.create(request, TEST_USER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("내용은 필수입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 목록 조회 서비스 테스트")
+    class GetPostsTest {
+
+        @Test
+        @DisplayName("게시글 목록 조회 성공")
+        void 게시글_목록_조회_성공() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Post> posts = List.of(
+                createPost(1L, "제목1", "내용1", 1L, TEST_CREATED_AT),
+                createPost(2L, "제목2", "내용2", 2L, TEST_CREATED_AT)
+            );
+            Page<Post> postPage = new PageImpl<>(posts, pageable, 2);
+            
+            when(postRepository.findAll(pageable)).thenReturn(postPage);
+
+            // when
+            Page<PostSummaryResponse> result = postService.getPosts(pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(result.getTotalPages()).isEqualTo(1);
+            assertThat(result.isLast()).isTrue();
+            
+            PostSummaryResponse firstPost = result.getContent().get(0);
+            assertThat(firstPost.id()).isEqualTo(1L);
+            assertThat(firstPost.title()).isEqualTo("제목1");
+            assertThat(firstPost.content()).isEqualTo("내용1");
+            assertThat(firstPost.userId()).isEqualTo(1L);
+            assertThat(firstPost.createdAt()).isEqualTo(TEST_CREATED_AT);
+
+            verify(postRepository).findAll(pageable);
+        }
+
+        @Test
+        @DisplayName("게시글 목록 조회 성공 - 빈 결과")
+        void 게시글_목록_조회_성공_빈결과() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<Post> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+            
+            when(postRepository.findAll(pageable)).thenReturn(emptyPage);
+
+            // when
+            Page<PostSummaryResponse> result = postService.getPosts(pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isEqualTo(0);
+            assertThat(result.getTotalPages()).isEqualTo(0);
+            assertThat(result.isLast()).isTrue();
+
+            verify(postRepository).findAll(pageable);
         }
     }
 


### PR DESCRIPTION
## 📌 PR 개요

- 게시글 목록 조회 API 구현
- 페이징 및 정렬 기능 포함
- 커스텀 응답 구조(`PostListResponse`) 적용

## 🔨 작업 내용 상세

- [x] `GET /posts` API 구현
- [x] `Pageable`을 통한 page, size, sort 기능 지원
- [x] 정렬 기본값 설정 (`createdAt DESC`)
- [x] 응답 형식 단순화를 위한 `PostListResponse` DTO 도입

## 🧪 테스트 방법

1. /posts?page=0&size=5&sort=createdAt,DESC

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/post-list-api`

## 📎 참고 사항

## 🧩 관련 이슈
