### PR TITLE
feat: 게시글 상세 조회 기능 구현 (#POST-DETAIL)

### DIFF
--- a/post-service/src/main/java/com/devloger/postservice/config/SecurityConfig.java
+++ b/post-service/src/main/java/com/devloger/postservice/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.devloger.postservice.config;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,16 +18,23 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        return http
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
+                // ✅ 인증 없이 허용할 요청들 (Swagger + GET /posts)
+                .requestMatchers(
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html"
+                ).permitAll()
+                .requestMatchers(HttpMethod.GET, "/posts").permitAll()
+                // ✅ 그 외는 인증 필요
                 .anyRequest().authenticated()
             )
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
-            .addFilterBefore(new CustomHeaderAuthFilter(), UsernamePasswordAuthenticationFilter.class);
-
-        return http.build();
+            .addFilterBefore(new CustomHeaderAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+            .build();
     }
 }

--- a/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
+++ b/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
@@ -2,6 +2,7 @@ package com.devloger.postservice.controller;
 
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
+import com.devloger.postservice.dto.PostDetailResponse;
 import com.devloger.postservice.dto.PostListResponse;
 import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.service.PostService;
@@ -44,5 +45,11 @@ public class PostController {
     ) {
         Page<PostSummaryResponse> page = postService.getPosts(pageable);
         return ResponseEntity.ok(PostListResponse.from(page));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "게시글 상세 조회", description = "게시글 ID를 이용해 상세 내용을 조회합니다.")
+    public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long id) {
+        return ResponseEntity.ok(postService.getPostById(id));
     }
 }

--- a/post-service/src/main/java/com/devloger/postservice/dto/PostDetailResponse.java
+++ b/post-service/src/main/java/com/devloger/postservice/dto/PostDetailResponse.java
@@ -1,0 +1,23 @@
+package com.devloger.postservice.dto;
+
+import com.devloger.postservice.domain.Post;
+
+import java.time.LocalDateTime;
+
+public record PostDetailResponse(
+    Long id,
+    String title,
+    String content,
+    Long userId,
+    LocalDateTime createdAt
+) {
+    public static PostDetailResponse from(Post post) {
+        return new PostDetailResponse(
+            post.getId(),
+            post.getTitle(),
+            post.getContent(),
+            post.getUserId(),
+            post.getCreatedAt()
+        );
+    }
+}

--- a/post-service/src/main/java/com/devloger/postservice/service/PostService.java
+++ b/post-service/src/main/java/com/devloger/postservice/service/PostService.java
@@ -4,7 +4,11 @@ import com.devloger.postservice.domain.Post;
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
 import com.devloger.postservice.dto.PostSummaryResponse;
+import com.devloger.postservice.dto.PostDetailResponse;
 import com.devloger.postservice.repository.PostRepository;
+import com.devloger.postservice.exception.CustomException;
+import com.devloger.postservice.exception.ErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,6 +45,13 @@ public class PostService {
         return postRepository.findAll(pageable)
                 .map(PostSummaryResponse::from);
     }
+
+    public PostDetailResponse getPostById(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        return PostDetailResponse.from(post);
+    }
+    
 
     private void validateRequest(PostCreateRequest request) {
         if (!StringUtils.hasText(request.title())) {

--- a/post-service/src/test/java/com/devloger/postservice/service/PostServiceTest.java
+++ b/post-service/src/test/java/com/devloger/postservice/service/PostServiceTest.java
@@ -4,7 +4,10 @@ import com.devloger.postservice.domain.Post;
 import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
 import com.devloger.postservice.dto.PostSummaryResponse;
+import com.devloger.postservice.dto.PostDetailResponse;
 import com.devloger.postservice.repository.PostRepository;
+import com.devloger.postservice.exception.CustomException;
+import com.devloger.postservice.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -176,6 +179,46 @@ class PostServiceTest {
             assertThat(result.isLast()).isTrue();
 
             verify(postRepository).findAll(pageable);
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 상세 조회 서비스 테스트")
+    class GetPostDetailTest {
+
+        @Test
+        @DisplayName("게시글 상세 조회 성공")
+        void 게시글_상세_조회_성공() {
+            // given
+            Post post = createPost(TEST_POST_ID, TEST_TITLE, TEST_CONTENT, TEST_USER_ID, TEST_CREATED_AT);
+            when(postRepository.findById(TEST_POST_ID)).thenReturn(java.util.Optional.of(post));
+
+            // when
+            PostDetailResponse result = postService.getPostById(TEST_POST_ID);
+
+            // then
+            assertThat(result.id()).isEqualTo(TEST_POST_ID);
+            assertThat(result.title()).isEqualTo(TEST_TITLE);
+            assertThat(result.content()).isEqualTo(TEST_CONTENT);
+            assertThat(result.userId()).isEqualTo(TEST_USER_ID);
+            assertThat(result.createdAt()).isEqualTo(TEST_CREATED_AT);
+
+            verify(postRepository).findById(TEST_POST_ID);
+        }
+
+        @Test
+        @DisplayName("게시글 상세 조회 실패 - 존재하지 않는 ID")
+        void 게시글_상세_조회_실패_존재하지_않는_ID() {
+            // given
+            Long invalidId = 999L;
+            when(postRepository.findById(invalidId)).thenReturn(java.util.Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.getPostById(invalidId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.POST_NOT_FOUND.getMessage());
+
+            verify(postRepository).findById(invalidId);
         }
     }
 


### PR DESCRIPTION
## 📌 PR 개요

- 게시글 상세 조회 기능 구현
- Swagger 문서화 및 단위 테스트 추가
- 예외 상황 (존재하지 않는 ID)에 대한 처리 로직 구현

## 🔨 작업 내용 상세

- [x] `GET /posts/{id}` API 구현
- [x] `PostService.getPostById()` 기능 구현
- [x] 존재하지 않는 게시글 조회 시 `POST_NOT_FOUND` 예외 처리

## 🧪 테스트 방법

1. Swagger 또는 Postman을 통해 `GET /posts/{id}` 호출
2. 존재하는 ID 요청 시 게시글 상세 내용 반환
3. 존재하지 않는 ID 요청 시 404 NOT_FOUND + CustomErrorResponse 확인

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/post-detail-api`

## 📎 참고 사항

## 🧩 관련 이슈

