### PR TITLE
feat: 게시글 수정 기능 추가

### DIFF
--- a/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
+++ b/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
@@ -5,6 +5,7 @@ import com.devloger.postservice.dto.PostCreateResponse;
 import com.devloger.postservice.dto.PostDetailResponse;
 import com.devloger.postservice.dto.PostListResponse;
 import com.devloger.postservice.dto.PostSummaryResponse;
+import com.devloger.postservice.dto.PostUpdateRequest;
 import com.devloger.postservice.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -52,4 +53,16 @@ public class PostController {
     public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long id) {
         return ResponseEntity.ok(postService.getPostById(id));
     }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "게시글 수정", description = "게시글 ID와 수정할 내용을 받아 게시글을 수정합니다. (작성자 본인만 수정 가능)")
+    public ResponseEntity<PostDetailResponse> updatePost(
+        @RequestHeader("X-User-Id") Long userId,
+        @PathVariable Long id,
+        @Valid @RequestBody PostUpdateRequest request
+    ) {
+        PostDetailResponse response = postService.update(id, userId, request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/post-service/src/main/java/com/devloger/postservice/domain/Post.java
+++ b/post-service/src/main/java/com/devloger/postservice/domain/Post.java
@@ -28,4 +28,10 @@ public class Post {
     public void setCreatedAt() {
         this.createdAt = LocalDateTime.now();
     }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+    
 }

--- a/post-service/src/main/java/com/devloger/postservice/dto/PostUpdateRequest.java
+++ b/post-service/src/main/java/com/devloger/postservice/dto/PostUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.devloger.postservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PostUpdateRequest(
+    @NotBlank(message = "제목은 필수 입력값입니다.")
+    String title,
+    
+    @NotBlank(message = "내용은 필수 입력값입니다.")
+    String content
+) {}

--- a/post-service/src/main/java/com/devloger/postservice/exception/ErrorCode.java
+++ b/post-service/src/main/java/com/devloger/postservice/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     VALIDATION_ERROR("VALIDATION_ERROR", "유효성 검사에 실패했습니다.", HttpStatus.BAD_REQUEST),
-    POST_NOT_FOUND("POST_NOT_FOUND", "존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND);
+    POST_NOT_FOUND("POST_NOT_FOUND", "존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_ACCESS("UNAUTHORIZED_ACCESS", "수정 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/post-service/src/main/java/com/devloger/postservice/service/PostService.java
+++ b/post-service/src/main/java/com/devloger/postservice/service/PostService.java
@@ -5,6 +5,7 @@ import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
 import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.dto.PostDetailResponse;
+import com.devloger.postservice.dto.PostUpdateRequest;
 import com.devloger.postservice.repository.PostRepository;
 import com.devloger.postservice.exception.CustomException;
 import com.devloger.postservice.exception.ErrorCode;
@@ -51,6 +52,22 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         return PostDetailResponse.from(post);
     }
+
+    public PostDetailResponse update(Long id, Long userId, PostUpdateRequest request) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    
+        if (!post.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    
+        post.update(request.title(), request.content());
+    
+        Post saved = postRepository.save(post);
+    
+        return PostDetailResponse.from(saved);
+    }
+    
     
 
     private void validateRequest(PostCreateRequest request) {

--- a/post-service/src/test/java/com/devloger/postservice/service/PostServiceTest.java
+++ b/post-service/src/test/java/com/devloger/postservice/service/PostServiceTest.java
@@ -5,9 +5,11 @@ import com.devloger.postservice.dto.PostCreateRequest;
 import com.devloger.postservice.dto.PostCreateResponse;
 import com.devloger.postservice.dto.PostSummaryResponse;
 import com.devloger.postservice.dto.PostDetailResponse;
+import com.devloger.postservice.dto.PostUpdateRequest;
 import com.devloger.postservice.repository.PostRepository;
 import com.devloger.postservice.exception.CustomException;
 import com.devloger.postservice.exception.ErrorCode;
+import com.devloger.postservice.util.TestDataUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,7 +22,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,13 +38,6 @@ class PostServiceTest {
 
     private PostService postService;
 
-    // 테스트 데이터
-    private static final String TEST_TITLE = "테스트 제목";
-    private static final String TEST_CONTENT = "테스트 내용";
-    private static final Long TEST_USER_ID = 1L;
-    private static final Long TEST_POST_ID = 1L;
-    private static final LocalDateTime TEST_CREATED_AT = LocalDateTime.now();
-
     @BeforeEach
     void setUp() {
         postService = new PostService(postRepository);
@@ -57,20 +51,22 @@ class PostServiceTest {
         @DisplayName("게시글 생성 성공")
         void 게시글_생성_성공() {
             // given
-            PostCreateRequest request = createPostRequest(TEST_TITLE, TEST_CONTENT);
-            Post savedPost = createPost(TEST_POST_ID, TEST_TITLE, TEST_CONTENT, TEST_USER_ID, TEST_CREATED_AT);
+            PostCreateRequest request = TestDataUtil.createPostRequest(TestDataUtil.TEST_TITLE, TestDataUtil.TEST_CONTENT);
+            Post savedPost = TestDataUtil.createPost(
+                TestDataUtil.TEST_POST_ID, TestDataUtil.TEST_TITLE, TestDataUtil.TEST_CONTENT, TestDataUtil.TEST_USER_ID, TestDataUtil.TEST_CREATED_AT
+            );
             
             when(postRepository.save(any(Post.class))).thenReturn(savedPost);
 
             // when
-            PostCreateResponse response = postService.create(request, TEST_USER_ID);
+            PostCreateResponse response = postService.create(request, TestDataUtil.TEST_USER_ID);
 
             // then
-            assertThat(response.id()).isEqualTo(TEST_POST_ID);
-            assertThat(response.title()).isEqualTo(TEST_TITLE);
-            assertThat(response.content()).isEqualTo(TEST_CONTENT);
-            assertThat(response.userId()).isEqualTo(TEST_USER_ID);
-            assertThat(response.createdAt()).isEqualTo(TEST_CREATED_AT);
+            assertThat(response.id()).isEqualTo(TestDataUtil.TEST_POST_ID);
+            assertThat(response.title()).isEqualTo(TestDataUtil.TEST_TITLE);
+            assertThat(response.content()).isEqualTo(TestDataUtil.TEST_CONTENT);
+            assertThat(response.userId()).isEqualTo(TestDataUtil.TEST_USER_ID);
+            assertThat(response.createdAt()).isEqualTo(TestDataUtil.TEST_CREATED_AT);
 
             verify(postRepository).save(any(Post.class));
         }
@@ -79,10 +75,10 @@ class PostServiceTest {
         @DisplayName("게시글 생성 실패 - 제목이 null인 경우")
         void 게시글_생성_실패_제목_null() {
             // given
-            PostCreateRequest request = createPostRequest(null, TEST_CONTENT);
+            PostCreateRequest request = TestDataUtil.createPostRequest(null, TestDataUtil.TEST_CONTENT);
 
             // when & then
-            assertThatThrownBy(() -> postService.create(request, TEST_USER_ID))
+            assertThatThrownBy(() -> postService.create(request, TestDataUtil.TEST_USER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("제목은 필수입니다.");
         }
@@ -91,10 +87,10 @@ class PostServiceTest {
         @DisplayName("게시글 생성 실패 - 내용이 null인 경우")
         void 게시글_생성_실패_내용_null() {
             // given
-            PostCreateRequest request = createPostRequest(TEST_TITLE, null);
+            PostCreateRequest request = TestDataUtil.createPostRequest(TestDataUtil.TEST_TITLE, null);
 
             // when & then
-            assertThatThrownBy(() -> postService.create(request, TEST_USER_ID))
+            assertThatThrownBy(() -> postService.create(request, TestDataUtil.TEST_USER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("내용은 필수입니다.");
         }
@@ -103,10 +99,10 @@ class PostServiceTest {
         @DisplayName("게시글 생성 실패 - 제목이 빈 문자열인 경우")
         void 게시글_생성_실패_제목_빈문자열() {
             // given
-            PostCreateRequest request = createPostRequest("", TEST_CONTENT);
+            PostCreateRequest request = TestDataUtil.createPostRequest("", TestDataUtil.TEST_CONTENT);
 
             // when & then
-            assertThatThrownBy(() -> postService.create(request, TEST_USER_ID))
+            assertThatThrownBy(() -> postService.create(request, TestDataUtil.TEST_USER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("제목은 필수입니다.");
         }
@@ -115,10 +111,10 @@ class PostServiceTest {
         @DisplayName("게시글 생성 실패 - 내용이 빈 문자열인 경우")
         void 게시글_생성_실패_내용_빈문자열() {
             // given
-            PostCreateRequest request = createPostRequest(TEST_TITLE, "");
+            PostCreateRequest request = TestDataUtil.createPostRequest(TestDataUtil.TEST_TITLE, "");
 
             // when & then
-            assertThatThrownBy(() -> postService.create(request, TEST_USER_ID))
+            assertThatThrownBy(() -> postService.create(request, TestDataUtil.TEST_USER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("내용은 필수입니다.");
         }
@@ -134,8 +130,8 @@ class PostServiceTest {
             // given
             Pageable pageable = PageRequest.of(0, 10);
             List<Post> posts = List.of(
-                createPost(1L, "제목1", "내용1", 1L, TEST_CREATED_AT),
-                createPost(2L, "제목2", "내용2", 2L, TEST_CREATED_AT)
+                TestDataUtil.createPost(1L, "제목1", "내용1", 1L, TestDataUtil.TEST_CREATED_AT),
+                TestDataUtil.createPost(2L, "제목2", "내용2", 2L, TestDataUtil.TEST_CREATED_AT)
             );
             Page<Post> postPage = new PageImpl<>(posts, pageable, 2);
             
@@ -155,7 +151,7 @@ class PostServiceTest {
             assertThat(firstPost.title()).isEqualTo("제목1");
             assertThat(firstPost.content()).isEqualTo("내용1");
             assertThat(firstPost.userId()).isEqualTo(1L);
-            assertThat(firstPost.createdAt()).isEqualTo(TEST_CREATED_AT);
+            assertThat(firstPost.createdAt()).isEqualTo(TestDataUtil.TEST_CREATED_AT);
 
             verify(postRepository).findAll(pageable);
         }
@@ -190,20 +186,22 @@ class PostServiceTest {
         @DisplayName("게시글 상세 조회 성공")
         void 게시글_상세_조회_성공() {
             // given
-            Post post = createPost(TEST_POST_ID, TEST_TITLE, TEST_CONTENT, TEST_USER_ID, TEST_CREATED_AT);
-            when(postRepository.findById(TEST_POST_ID)).thenReturn(java.util.Optional.of(post));
+            Post post = TestDataUtil.createPost(
+                TestDataUtil.TEST_POST_ID, TestDataUtil.TEST_TITLE, TestDataUtil.TEST_CONTENT, TestDataUtil.TEST_USER_ID, TestDataUtil.TEST_CREATED_AT
+            );
+            when(postRepository.findById(TestDataUtil.TEST_POST_ID)).thenReturn(java.util.Optional.of(post));
 
             // when
-            PostDetailResponse result = postService.getPostById(TEST_POST_ID);
+            PostDetailResponse result = postService.getPostById(TestDataUtil.TEST_POST_ID);
 
             // then
-            assertThat(result.id()).isEqualTo(TEST_POST_ID);
-            assertThat(result.title()).isEqualTo(TEST_TITLE);
-            assertThat(result.content()).isEqualTo(TEST_CONTENT);
-            assertThat(result.userId()).isEqualTo(TEST_USER_ID);
-            assertThat(result.createdAt()).isEqualTo(TEST_CREATED_AT);
+            assertThat(result.id()).isEqualTo(TestDataUtil.TEST_POST_ID);
+            assertThat(result.title()).isEqualTo(TestDataUtil.TEST_TITLE);
+            assertThat(result.content()).isEqualTo(TestDataUtil.TEST_CONTENT);
+            assertThat(result.userId()).isEqualTo(TestDataUtil.TEST_USER_ID);
+            assertThat(result.createdAt()).isEqualTo(TestDataUtil.TEST_CREATED_AT);
 
-            verify(postRepository).findById(TEST_POST_ID);
+            verify(postRepository).findById(TestDataUtil.TEST_POST_ID);
         }
 
         @Test
@@ -222,18 +220,61 @@ class PostServiceTest {
         }
     }
 
-    // 테스트 데이터 생성 메서드
-    private PostCreateRequest createPostRequest(String title, String content) {
-        return new PostCreateRequest(title, content);
-    }
+    @Nested
+    @DisplayName("게시글 수정 서비스 테스트")
+    class UpdatePostTest {
 
-    private Post createPost(Long id, String title, String content, Long userId, LocalDateTime createdAt) {
-        return Post.builder()
-                .id(id)
-                .title(title)
-                .content(content)
-                .userId(userId)
-                .createdAt(createdAt)
-                .build();
+        @Test
+        @DisplayName("게시글 수정 성공")
+        void 게시글_수정_성공() {
+            // given
+            Post post = TestDataUtil.createPost(
+                TestDataUtil.TEST_POST_ID, TestDataUtil.TEST_TITLE, TestDataUtil.TEST_CONTENT, TestDataUtil.TEST_USER_ID, TestDataUtil.TEST_CREATED_AT
+            );
+            PostUpdateRequest request = new PostUpdateRequest("수정된 제목", "수정된 내용");
+
+            when(postRepository.findById(TestDataUtil.TEST_POST_ID)).thenReturn(java.util.Optional.of(post));
+            when(postRepository.save(any(Post.class))).thenReturn(post);
+
+            // when
+            PostDetailResponse result = postService.update(TestDataUtil.TEST_POST_ID, TestDataUtil.TEST_USER_ID, request);
+
+            // then
+            assertThat(result.title()).isEqualTo("수정된 제목");
+            assertThat(result.content()).isEqualTo("수정된 내용");
+            verify(postRepository).save(any(Post.class));
+        }
+
+        @Test
+        @DisplayName("게시글 수정 실패 - 작성자가 아님")
+        void 게시글_수정_실패_권한없음() {
+            // given
+            Post post = TestDataUtil.createPost(
+                TestDataUtil.TEST_POST_ID, TestDataUtil.TEST_TITLE, TestDataUtil.TEST_CONTENT, TestDataUtil.TEST_USER_ID, TestDataUtil.TEST_CREATED_AT
+            );
+            Long otherUserId = 2L;
+            PostUpdateRequest request = new PostUpdateRequest("수정된 제목", "수정된 내용");
+
+            when(postRepository.findById(TestDataUtil.TEST_POST_ID)).thenReturn(java.util.Optional.of(post));
+
+            // when & then
+            assertThatThrownBy(() -> postService.update(TestDataUtil.TEST_POST_ID, otherUserId, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.UNAUTHORIZED_ACCESS.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글 수정 실패 - 존재하지 않는 게시글")
+        void 게시글_수정_실패_존재하지_않음() {
+            // given
+            PostUpdateRequest request = new PostUpdateRequest("수정된 제목", "수정된 내용");
+
+            when(postRepository.findById(TestDataUtil.TEST_POST_ID)).thenReturn(java.util.Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.update(TestDataUtil.TEST_POST_ID, TestDataUtil.TEST_USER_ID, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.POST_NOT_FOUND.getMessage());
+        }
     }
 } 

--- a/post-service/src/test/java/com/devloger/postservice/util/TestDataUtil.java
+++ b/post-service/src/test/java/com/devloger/postservice/util/TestDataUtil.java
@@ -1,0 +1,45 @@
+package com.devloger.postservice.util;
+
+import com.devloger.postservice.domain.Post;
+import com.devloger.postservice.dto.PostCreateRequest;
+import com.devloger.postservice.dto.PostCreateResponse;
+import com.devloger.postservice.dto.PostDetailResponse;
+import com.devloger.postservice.dto.PostSummaryResponse;
+
+import java.time.LocalDateTime;
+
+public class TestDataUtil {
+    // 테스트 데이터 상수
+    public static final String TEST_TITLE = "테스트 제목";
+    public static final String TEST_CONTENT = "테스트 내용";
+    public static final Long TEST_USER_ID = 1L;
+    public static final Long TEST_POST_ID = 1L;
+    public static final LocalDateTime TEST_CREATED_AT = LocalDateTime.now();
+
+    // 테스트 데이터 생성 메서드
+    public static PostCreateRequest createPostRequest(String title, String content) {
+        return new PostCreateRequest(title, content);
+    }
+
+    public static Post createPost(Long id, String title, String content, Long userId, LocalDateTime createdAt) {
+        return Post.builder()
+                .id(id)
+                .title(title)
+                .content(content)
+                .userId(userId)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    public static PostCreateResponse createPostResponse(Long id, String title, String content, Long userId, LocalDateTime createdAt) {
+        return new PostCreateResponse(id, title, content, userId, createdAt);
+    }
+
+    public static PostDetailResponse createPostDetailResponse(Long id, String title, String content, Long userId, LocalDateTime createdAt) {
+        return new PostDetailResponse(id, title, content, userId, createdAt);
+    }
+
+    public static PostSummaryResponse createPostSummaryResponse(Long id, String title, String content, Long userId, LocalDateTime createdAt) {
+        return new PostSummaryResponse(id, title, content, userId, createdAt);
+    }
+} 


### PR DESCRIPTION
## 📌 PR 개요

- 게시글 수정(Update) 기능 추가
- 작성자 본인만 수정 가능하도록 권한 체크 추가
- Controller, Service 계층 통합 테스트 코드 작성 완료
- 테스트 공통 데이터 유틸리티 `TestDataUtil` 클래스로 분리하여 중복 제거

## 🔨 작업 내용 상세

- [x] `PATCH /posts/{id}` API 구현
- [x] 본인만 수정 가능 (`X-User-Id` 헤더 기반 검증)
- [x] 테스트 공통 유틸리티(TestDataUtil)로 통합 리팩터링

## 🧪 테스트 방법

1. Swagger 또는 Postman에서
   - PATCH `/posts/{id}` 호출
   - Body에 `title`, `content` JSON 입력
   - `X-User-Id` 헤더 추가
2. 작성자가 아닌 경우 403 Forbidden 응답 확인

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/post-update-api`

## 📎 참고 사항

## 🧩 관련 이슈

