### PR TITLE
feat: 게시글 삭제 기능 추가

### DIFF
--- a/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
+++ b/post-service/src/main/java/com/devloger/postservice/controller/PostController.java
@@ -65,4 +65,14 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    @DeleteMapping("/{id}")
+    @Operation(summary = "게시글 삭제", description = "게시글을 소프트 삭제합니다. 작성자만 삭제 가능")
+    public ResponseEntity<Void> deletePost(
+        @RequestHeader("X-User-Id") Long userId,
+        @PathVariable Long id
+    ) {
+        postService.delete(id, userId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/post-service/src/main/java/com/devloger/postservice/domain/Post.java
+++ b/post-service/src/main/java/com/devloger/postservice/domain/Post.java
@@ -2,7 +2,7 @@ package com.devloger.postservice.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-
+import org.hibernate.annotations.SQLRestriction;
 import java.time.LocalDateTime;
 
 @Entity
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLRestriction("deleted_at IS NULL")
 public class Post {
 
     @Id
@@ -24,14 +25,28 @@ public class Post {
 
     private LocalDateTime createdAt;
 
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
     @PrePersist
     public void setCreatedAt() {
         this.createdAt = LocalDateTime.now();
     }
 
+    @PreUpdate
+    public void setUpdatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
-    }
+    }    
     
 }

--- a/post-service/src/main/java/com/devloger/postservice/service/PostService.java
+++ b/post-service/src/main/java/com/devloger/postservice/service/PostService.java
@@ -67,6 +67,19 @@ public class PostService {
     
         return PostDetailResponse.from(saved);
     }
+
+    public void delete(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    
+        if (!post.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    
+        post.softDelete();
+        postRepository.save(post); // ✅ 꼭 저장해줘야 DB에 반영돼
+    }
+    
     
     
 


### PR DESCRIPTION
## 📌 PR 개요

- 게시글 삭제(Delete) 기능 추가 (Soft Delete 방식)
- @SQLRestriction을 이용한 조회 시 삭제된 데이터 제외
- 삭제 관련 단위 테스트(Controller + Service) 작성 및 통과

## 🔨 작업 내용 상세

- [x] `DELETE /posts/{id}` API 구현
- [x] `Post` Entity에 `deletedAt` 컬럼 추가 및 soft delete 메소드 구현
- [x] `@SQLRestriction("deleted_at IS NULL")` 적용
- [x] 삭제 시 작성자 검증 로직 추가 (본인 글만 삭제 가능)

## 🧪 테스트 방법

1. Swagger나 Postman으로
2. `DELETE /posts/{id}` 요청 보내기
3. 삭제 성공(204) / 삭제 실패 시 적절한 에러 코드 (`POST_NOT_FOUND`, `UNAUTHORIZED_ACCESS`) 확인

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/post-delete-soft`

## 📎 참고 사항

- Soft delete 적용으로 인해 findAll, findById 결과에서 삭제된 데이터는 제외됩니다.
- Hibernate 6.3 이상에서는 `@Where` 대신 `@SQLRestriction`을 사용해야 합니다 (최신 버전에 맞춰 수정 완료).

## 🧩 관련 이슈
