### PR TITLE
feat: Spring Boot 버전 통일 및 docker-compose 구축

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk17 AS build
+WORKDIR /workspace
+
+# 루트 프로젝트의 gradle 설정 복사
+COPY gradle ./gradle
+COPY gradlew .
+COPY gradlew.bat .
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# 서비스별 소스 복사
+COPY api-gateway ./api-gateway
+
+# 빌드
+RUN ./gradlew :api-gateway:bootJar --no-daemon
+
+# Run stage
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+# 빌드 결과물 복사
+COPY --from=build /workspace/api-gateway/build/libs/*.jar app.jar
+
+# 환경변수 기본 설정 (포트 오픈)
+EXPOSE 8000
+
+# 실행
+ENTRYPOINT ["java", "-jar", "app.jar"] 

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -19,6 +19,9 @@ RUN ./gradlew :api-gateway:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# curl 설치
+RUN apt-get update && apt-get install -y curl
+
 # 빌드 결과물 복사
 COPY --from=build /workspace/api-gateway/build/libs/*.jar app.jar
 

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "3.2.3"
+    id("org.springframework.boot") version "3.1.9" // 🔁 Spring Boot 3.2.3 → 3.1.9
     id("io.spring.dependency-management") version "1.1.3"
     id("java")
 }
@@ -12,6 +12,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
@@ -22,7 +28,6 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
-    // yml 자동 바인딩
     implementation("org.springframework.boot:spring-boot-configuration-processor")
 
     compileOnly("org.projectlombok:lombok")

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
@@ -29,7 +30,7 @@ dependencies {
 }
 
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {
-    mainClass.set("com.devloger.apigateway.ApigatewayApplication")
+    mainClass.set("com.devloger.apigateway.ApiGatewayApplication")
 }
 
 tasks.withType<JavaCompile> {

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -24,7 +24,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://eureka-server:8761/eureka
+    # 💡 Eureka 서버 재시도 옵션 추가
+    healthcheck:
+      enabled: true
+    registry-fetch-interval-seconds: 5
+    initial-instance-info-replication-interval-seconds: 5
 
 jwt:
   secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!"

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk17 AS build
+WORKDIR /workspace
+
+# 루트 프로젝트의 gradle 설정 복사
+COPY gradle ./gradle
+COPY gradlew .
+COPY gradlew.bat .
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# 서비스별 소스 복사
+COPY auth-service ./auth-service
+
+# 빌드
+RUN ./gradlew :auth-service:bootJar --no-daemon
+
+# Run stage
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+# 빌드 결과물 복사
+COPY --from=build /workspace/auth-service/build/libs/*.jar app.jar
+
+# 환경변수 기본 설정 (포트 오픈)
+EXPOSE 8081
+
+# 실행
+ENTRYPOINT ["java", "-jar", "app.jar"] 

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -19,6 +19,9 @@ RUN ./gradlew :auth-service:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# curl 설치
+RUN apt-get update && apt-get install -y curl
+
 # 대기 스크립트 추가
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -19,6 +19,10 @@ RUN ./gradlew :auth-service:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# 대기 스크립트 추가
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod +x /wait-for-it.sh
+
 # 빌드 결과물 복사
 COPY --from=build /workspace/auth-service/build/libs/*.jar app.jar
 
@@ -26,4 +30,4 @@ COPY --from=build /workspace/auth-service/build/libs/*.jar app.jar
 EXPOSE 8081
 
 # 실행
-ENTRYPOINT ["java", "-jar", "app.jar"] 
+ENTRYPOINT ["/wait-for-it.sh", "mysql-auth:3306", "--", "java", "-jar", "app.jar"] 

--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "3.2.3"
+    id("org.springframework.boot") version "3.1.9"
     id("io.spring.dependency-management") version "1.1.3"
     id("java")
 }
@@ -10,6 +10,12 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
 }
 
 dependencies {
@@ -31,16 +37,15 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    //DB 설정
+    // DB 설정
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-security") // BCrypt
+    implementation("org.springframework.boot:spring-boot-starter-security")
     runtimeOnly("com.mysql:mysql-connector-j")
 
-    //테스트
+    // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
-
 
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {
     mainClass.set("com.devloger.authservice.AuthserviceApplication")

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: auth-service
 
   datasource:
-    url: jdbc:mysql://localhost:3306/devloger_auth?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://mysql-auth:3306/devloger_auth?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: 1234
@@ -24,7 +24,12 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://eureka-server:8761/eureka
+    # 💡 Eureka 서버 재시도 옵션 추가
+    healthcheck:
+      enabled: true
+    registry-fetch-interval-seconds: 5
+    initial-instance-info-replication-interval-seconds: 5
 
 jwt:
   secret: "devloger-super-secret-key-1234567890-jwt-secure-key!!" # 256비트 이상

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,27 @@
 plugins {
-    id("org.springframework.boot") version "3.2.3" apply false
+    id("org.springframework.boot") version "3.1.9" apply false
     id("io.spring.dependency-management") version "1.1.3"
+    id("java") // 각 subproject에 필요하므로 명시
 }
 
 subprojects {
     apply(plugin = "org.springframework.boot")
     apply(plugin = "io.spring.dependency-management")
+    apply(plugin = "java")
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     dependencyManagement {
         imports {
-            mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.1")
+            mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
         }
     }
 
     repositories {
         mavenCentral()
+        maven { url = uri("https://repo.spring.io/milestone") }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
+    id("org.springframework.boot") version "3.2.3" apply false
     id("io.spring.dependency-management") version "1.1.3"
 }
 
 subprojects {
+    apply(plugin = "org.springframework.boot")
     apply(plugin = "io.spring.dependency-management")
 
     dependencyManagement {

--- a/comment-service/Dockerfile
+++ b/comment-service/Dockerfile
@@ -19,6 +19,9 @@ RUN ./gradlew :comment-service:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# curl 설치
+RUN apt-get update && apt-get install -y curl
+
 # 빌드 결과물 복사
 COPY --from=build /workspace/comment-service/build/libs/*.jar app.jar
 

--- a/comment-service/Dockerfile
+++ b/comment-service/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk17 AS build
+WORKDIR /workspace
+
+# 루트 프로젝트의 gradle 설정 복사
+COPY gradle ./gradle
+COPY gradlew .
+COPY gradlew.bat .
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# 서비스별 소스 복사
+COPY comment-service ./comment-service
+
+# 빌드
+RUN ./gradlew :comment-service:bootJar --no-daemon
+
+# Run stage
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+# 빌드 결과물 복사
+COPY --from=build /workspace/comment-service/build/libs/*.jar app.jar
+
+# 환경변수 기본 설정 (포트 오픈)
+EXPOSE 8083
+
+# 실행
+ENTRYPOINT ["java", "-jar", "app.jar"] 

--- a/comment-service/build.gradle.kts
+++ b/comment-service/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "3.2.3"
+    id("org.springframework.boot") version "3.1.9"
     id("io.spring.dependency-management") version "1.1.3"
     id("java")
 }
@@ -10,6 +10,12 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
 }
 
 dependencies {

--- a/comment-service/src/main/resources/application.yml
+++ b/comment-service/src/main/resources/application.yml
@@ -10,4 +10,9 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://eureka-server:8761/eureka
+    # 💡 Eureka 서버 재시도 옵션 추가
+    healthcheck:
+      enabled: true
+    registry-fetch-interval-seconds: 5
+    initial-instance-info-replication-interval-seconds: 5

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -19,6 +19,9 @@ RUN ./gradlew :discovery-server:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# curl 설치
+RUN apt-get update && apt-get install -y curl
+
 # 빌드 결과물 복사
 COPY --from=build /workspace/discovery-server/build/libs/*.jar app.jar
 

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk17 AS build
+WORKDIR /workspace
+
+# 루트 프로젝트의 gradle 설정 복사
+COPY gradle ./gradle
+COPY gradlew .
+COPY gradlew.bat .
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# 서비스별 소스 복사
+COPY discovery-server ./discovery-server
+
+# 빌드
+RUN ./gradlew :discovery-server:bootJar --no-daemon
+
+# Run stage
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+# 빌드 결과물 복사
+COPY --from=build /workspace/discovery-server/build/libs/*.jar app.jar
+
+# 환경변수 기본 설정 (포트 오픈)
+EXPOSE 8761
+
+# 실행
+ENTRYPOINT ["java", "-jar", "app.jar"] 

--- a/discovery-server/build.gradle.kts
+++ b/discovery-server/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "3.2.3"
+    id("org.springframework.boot") version "3.1.9"
     id("io.spring.dependency-management") version "1.1.3"
     id("java")
 }
@@ -14,7 +14,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.0")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
     }
 }
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "8761:8761"
     networks:
       - devloger-net
+    restart: unless-stopped
 
   mysql-auth:
     container_name: mysql-auth
@@ -21,6 +22,9 @@ services:
       MYSQL_DATABASE: devloger_auth
     networks:
       - devloger-net
+    volumes:
+      - mysql-auth-data:/var/lib/mysql
+    restart: unless-stopped
 
   mysql-post:
     container_name: mysql-post
@@ -32,6 +36,10 @@ services:
       MYSQL_DATABASE: devloger_post
     networks:
       - devloger-net
+    volumes:
+      - mysql-post-data:/var/lib/mysql
+    restart: unless-stopped
+
 
   auth-service:
     container_name: auth-service
@@ -50,6 +58,7 @@ services:
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: 1234
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+    restart: unless-stopped
 
   post-service:
     container_name: post-service
@@ -68,6 +77,7 @@ services:
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: 1234
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+    restart: unless-stopped
 
   comment-service:
     container_name: comment-service
@@ -82,6 +92,7 @@ services:
       - devloger-net
     environment:
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+    restart: unless-stopped
 
   api-gateway:
     container_name: api-gateway
@@ -96,7 +107,12 @@ services:
       - devloger-net
     environment:
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+    restart: unless-stopped
 
 networks:
   devloger-net:
     driver: bridge
+
+volumes:
+  mysql-auth-data:
+  mysql-post-data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -11,6 +11,13 @@ services:
     networks:
       - devloger-net
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8761/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
 
   mysql-auth:
     container_name: mysql-auth
@@ -25,6 +32,11 @@ services:
     volumes:
       - mysql-auth-data:/var/lib/mysql
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   mysql-post:
     container_name: mysql-post
@@ -39,6 +51,11 @@ services:
     volumes:
       - mysql-post-data:/var/lib/mysql
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
 
   auth-service:
@@ -59,6 +76,12 @@ services:
       SPRING_DATASOURCE_PASSWORD: 1234
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   post-service:
     container_name: post-service
@@ -78,6 +101,12 @@ services:
       SPRING_DATASOURCE_PASSWORD: 1234
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   comment-service:
     container_name: comment-service
@@ -93,6 +122,13 @@ services:
     environment:
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8083/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
 
   api-gateway:
     container_name: api-gateway
@@ -108,6 +144,13 @@ services:
     environment:
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
 
 networks:
   devloger-net:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,102 @@
+version: '3.8'
+
+services:
+  eureka-server:
+    container_name: eureka-server
+    build:
+      context: ..
+      dockerfile: discovery-server/Dockerfile
+    ports:
+      - "8761:8761"
+    networks:
+      - devloger-net
+
+  mysql-auth:
+    container_name: mysql-auth
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: devloger_auth
+    networks:
+      - devloger-net
+
+  mysql-post:
+    container_name: mysql-post
+    image: mysql:8
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: devloger_post
+    networks:
+      - devloger-net
+
+  auth-service:
+    container_name: auth-service
+    build:
+      context: ..
+      dockerfile: auth-service/Dockerfile
+    ports:
+      - "8081:8081"
+    depends_on:
+      - mysql-auth
+      - eureka-server
+    networks:
+      - devloger-net
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql-auth:3306/devloger_auth?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: 1234
+      EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+
+  post-service:
+    container_name: post-service
+    build:
+      context: ..
+      dockerfile: post-service/Dockerfile
+    ports:
+      - "8082:8082"
+    depends_on:
+      - mysql-post
+      - eureka-server
+    networks:
+      - devloger-net
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql-post:3306/devloger_post?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: 1234
+      EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+
+  comment-service:
+    container_name: comment-service
+    build:
+      context: ..
+      dockerfile: comment-service/Dockerfile
+    ports:
+      - "8083:8083"
+    depends_on:
+      - eureka-server
+    networks:
+      - devloger-net
+    environment:
+      EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+
+  api-gateway:
+    container_name: api-gateway
+    build:
+      context: ..
+      dockerfile: api-gateway/Dockerfile
+    ports:
+      - "8000:8000"
+    depends_on:
+      - eureka-server
+    networks:
+      - devloger-net
+    environment:
+      EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka
+
+networks:
+  devloger-net:
+    driver: bridge

--- a/post-service/Dockerfile
+++ b/post-service/Dockerfile
@@ -19,6 +19,10 @@ RUN ./gradlew :post-service:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# 대기 스크립트 추가
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod +x /wait-for-it.sh
+
 # 빌드 결과물 복사
 COPY --from=build /workspace/post-service/build/libs/*.jar app.jar
 
@@ -26,4 +30,4 @@ COPY --from=build /workspace/post-service/build/libs/*.jar app.jar
 EXPOSE 8082
 
 # 실행
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["/wait-for-it.sh", "mysql-post:3306", "--", "java", "-jar", "app.jar"]

--- a/post-service/Dockerfile
+++ b/post-service/Dockerfile
@@ -19,6 +19,9 @@ RUN ./gradlew :post-service:bootJar --no-daemon
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
+# curl 설치
+RUN apt-get update && apt-get install -y curl
+
 # 대기 스크립트 추가
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh

--- a/post-service/Dockerfile
+++ b/post-service/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk17 AS build
+WORKDIR /workspace
+
+# 루트 프로젝트의 gradle 설정 복사
+COPY gradle ./gradle
+COPY gradlew .
+COPY gradlew.bat .
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# 서비스별 소스 복사
+COPY post-service ./post-service
+
+# 빌드
+RUN ./gradlew :post-service:bootJar --no-daemon
+
+# Run stage
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+# 빌드 결과물 복사
+COPY --from=build /workspace/post-service/build/libs/*.jar app.jar
+
+# 환경변수 기본 설정 (포트 오픈)
+EXPOSE 8082
+
+# 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/post-service/build.gradle.kts
+++ b/post-service/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "3.2.3"
+    id("org.springframework.boot") version "3.1.9"
     id("io.spring.dependency-management") version "1.1.3"
     id("java")
 }
@@ -12,12 +12,18 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.5")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
-        // OpenAPI
+    // OpenAPI
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
     // yml 자동 바인딩
@@ -26,13 +32,13 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    //DB 설정
+    // DB 설정
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-security") // BCrypt
+    implementation("org.springframework.boot:spring-boot-starter-security")
     runtimeOnly("com.mysql:mysql-connector-j")
 
-    //테스트
+    // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/post-service/src/main/java/com/devloger/postservice/domain/Post.java
+++ b/post-service/src/main/java/com/devloger/postservice/domain/Post.java
@@ -2,15 +2,14 @@ package com.devloger.postservice.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
 import java.time.LocalDateTime;
-
+import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@SQLRestriction("deleted_at IS NULL")
+@Where(clause = "deleted_at IS NULL")
 public class Post {
 
     @Id

--- a/post-service/src/main/resources/application.yml
+++ b/post-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: post-service
 
   datasource:
-    url: jdbc:mysql://mysql-post:3307/devloger_post?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://mysql-post:3306/devloger_post?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: 1234

--- a/post-service/src/main/resources/application.yml
+++ b/post-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: post-service
 
   datasource:
-    url: jdbc:mysql://localhost:3307/devloger_post?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://mysql-post:3307/devloger_post?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: 1234
@@ -24,4 +24,9 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://eureka-server:8761/eureka
+    # 💡 Eureka 서버 재시도 옵션 추가
+    healthcheck:
+      enabled: true
+    registry-fetch-interval-seconds: 5
+    initial-instance-info-replication-interval-seconds: 5


### PR DESCRIPTION
## 📌 PR 개요

- Spring Boot 버전 통일 (3.2.3 → 3.1.9)
- 도커 환경 구성 완료 (Dockerfile, docker-compose.yaml)
- Dockerfile 작성 및 서비스 단위 컨테이너화
- docker-compose 구성으로 전체 서비스 부팅 자동화

## 🔨 작업 내용 상세

- [x] 각 서비스 Dockerfile 작성 및 build 단계 분리
- [x] docker 환경에서 스프링부트 3.2.x 사용 시 actuator 관련 이슈로 인해 전체 서비스를 3.1.9로 다운그레이드

## 🧪 테스트 방법

- `docker-compose up --build`로 전체 서비스 정상 기동 확인
- Eureka Dashboard에서 모든 서비스 정상 등록 확인
- MySQL 컨테이너 초기화 및 연결 성공 확인

## 🔄 변경 브랜치

- **Base branch:** `develop`
- **Target branch:** `feature/update-docker-compose`

## 📎 참고 사항

## 🧩 관련 이슈
- spring-web-flux 와 actuator 의 버전 문제로 docker-compose 빌드 시 빌드가 실패하는 현상이 발생,
- 스프링 부트 3.2.x 에서 actuator 사용 불가로 인해 3.1.x로 다운그레이드함

